### PR TITLE
chore(logger): add logger utility and replace all console.log

### DIFF
--- a/src/components/ai/AIAlertBannerWrapper.tsx
+++ b/src/components/ai/AIAlertBannerWrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '@/hooks/useTheme';
+import { logger } from '@/utils/logger';
 import type { AISuggestion } from '@/utils/aiPredictions';
 
 // Type pour les alertes IA du web component
@@ -69,7 +70,7 @@ export const AIAlertBannerWrapper: React.FC<AIAlertBannerWrapperProps> = ({
   // Handler pour le clic sur un item
   const handleItemClick = (e: Event) => {
     const detail = e instanceof CustomEvent ? e.detail : null;
-    console.log('🤖 Alert item clicked:', detail);
+    logger.debug('Alert item clicked:', detail);
     // TODO: Navigation vers le stock concerné
   };
 

--- a/src/components/ai/__tests__/AIAlertBannerWrapper.test.tsx
+++ b/src/components/ai/__tests__/AIAlertBannerWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { AIAlertBannerWrapper } from '../AIAlertBannerWrapper';
+import * as loggerModule from '@/utils/logger';
 import type { AISuggestion } from '@/utils/aiPredictions';
 
 // Mock useTheme
@@ -8,8 +9,8 @@ vi.mock('@/hooks/useTheme', () => ({
   useTheme: () => ({ theme: 'dark' }),
 }));
 
-// Mock console.log to avoid noise in tests
-const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+// Spy on logger.debug (replaces console.log spying)
+const loggerDebugSpy = vi.spyOn(loggerModule.logger, 'debug').mockImplementation(() => {});
 
 // Mock AI suggestions
 const criticalSuggestion: AISuggestion = {
@@ -248,9 +249,9 @@ describe('AIAlertBannerWrapper', () => {
       });
       banner?.dispatchEvent(event);
 
-      // Verify console.log was called
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        '🤖 Alert item clicked:',
+      // Verify logger.debug was called
+      expect(loggerDebugSpy).toHaveBeenCalledWith(
+        'Alert item clicked:',
         expect.objectContaining({ product: 'Test Product', index: 0 })
       );
     });

--- a/src/components/dashboard/StockCardWrapper.tsx
+++ b/src/components/dashboard/StockCardWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '@/hooks/useTheme';
+import { logger } from '@/utils/logger';
 import type { StockCardProps } from '@/types';
 import type { WebComponentStatus } from '@/types/web-component-events';
 import type { StockStatus, Stock } from '@/types/stock';
@@ -61,10 +62,10 @@ export const StockCardWrapper: React.FC<StockCardProps> = ({
         ...localStock,
         quantity: result.newQuantity,
       });
-      console.log(`🎨 ${result.message}`);
+      logger.info(result.message);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
-      console.error(`❌ ${errorMessage}`);
+      logger.error(errorMessage);
     }
   };
 

--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '@/hooks/useTheme';
+import { logger } from '@/utils/logger';
 import type { HeaderProps } from '@/types';
 
 /**
@@ -13,7 +14,7 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   const { theme, toggleTheme } = useTheme();
 
   const handleNotifications = () => {
-    console.log('🔔 Notifications clicked');
+    logger.debug('Notifications clicked');
     // TODO: Ouvrir le panneau de notifications
   };
 
@@ -22,7 +23,7 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   };
 
   const handleLogout = () => {
-    console.log('👋 Logout clicked');
+    logger.debug('Logout clicked');
     // TODO: Implémenter la logique de logout
   };
 

--- a/src/components/layout/__tests__/HeaderWrapper.test.tsx
+++ b/src/components/layout/__tests__/HeaderWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { HeaderWrapper } from '../HeaderWrapper';
+import * as loggerModule from '@/utils/logger';
 
 // Mock useTheme
 const mockToggleTheme = vi.fn();
@@ -11,8 +12,8 @@ vi.mock('@/hooks/useTheme', () => ({
   }),
 }));
 
-// Mock console.log to avoid noise in tests
-const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+// Spy on logger.debug (replaces console.log spying)
+const loggerDebugSpy = vi.spyOn(loggerModule.logger, 'debug').mockImplementation(() => {});
 
 describe('HeaderWrapper', () => {
   beforeEach(() => {
@@ -131,7 +132,7 @@ describe('HeaderWrapper', () => {
       const event = new Event('sh-notification-click', { bubbles: true });
       header?.dispatchEvent(event);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('🔔 Notifications clicked');
+      expect(loggerDebugSpy).toHaveBeenCalledWith('Notifications clicked');
     });
 
     it('should not crash on multiple notification clicks', () => {
@@ -146,7 +147,7 @@ describe('HeaderWrapper', () => {
         header?.dispatchEvent(event2);
       }).not.toThrow();
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+      expect(loggerDebugSpy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -158,7 +159,7 @@ describe('HeaderWrapper', () => {
       const event = new Event('sh-logout-click', { bubbles: true });
       header?.dispatchEvent(event);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('👋 Logout clicked');
+      expect(loggerDebugSpy).toHaveBeenCalledWith('Logout clicked');
     });
 
     it('should not crash on multiple logout clicks', () => {
@@ -188,9 +189,9 @@ describe('HeaderWrapper', () => {
       header?.dispatchEvent(themeEvent);
       header?.dispatchEvent(logoutEvent);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('🔔 Notifications clicked');
+      expect(loggerDebugSpy).toHaveBeenCalledWith('Notifications clicked');
       expect(mockToggleTheme).toHaveBeenCalledTimes(1);
-      expect(consoleLogSpy).toHaveBeenCalledWith('👋 Logout clicked');
+      expect(loggerDebugSpy).toHaveBeenCalledWith('Logout clicked');
     });
   });
 

--- a/src/hooks/__tests__/useFrontendState.test.tsx
+++ b/src/hooks/__tests__/useFrontendState.test.tsx
@@ -7,6 +7,7 @@ import {
   useFrontendState,
   useLocalStorageState,
 } from '@/hooks/useFrontendState';
+import * as loggerModule from '@/utils/logger';
 
 const originalCreateElement = document.createElement.bind(document);
 
@@ -541,15 +542,15 @@ describe('useLocalStorageState Hook', () => {
     });
 
     it('should handle JSON parse errors gracefully', () => {
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loggerWarnSpy = vi.spyOn(loggerModule.logger, 'warn').mockImplementation(() => {});
       localStorage.setItem('test-key', 'invalid json');
 
       const { result } = renderHook(() => useLocalStorageState('test-key', 'default'));
 
       expect(result.current.value).toBe('default');
-      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(loggerWarnSpy).toHaveBeenCalled();
 
-      consoleWarnSpy.mockRestore();
+      loggerWarnSpy.mockRestore();
     });
   });
 

--- a/src/hooks/useFrontendState.ts
+++ b/src/hooks/useFrontendState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { AsyncFrontendState, FrontendError, FrontendErrorType } from '@/types';
+import { logger } from '@/utils/logger';
 
 // ===== HOOK PRINCIPAL POUR GESTION D'ÉTATS =====
 export const useFrontendState = <T>(initialData: T | null = null) => {
@@ -446,7 +447,7 @@ export const useLocalStorageState = <T>(key: string, initialValue: T) => {
       const item = localStorage.getItem(key);
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
-      console.warn(`Erreur lors de la lecture du localStorage pour la clé "${key}":`, error);
+      logger.warn(`Erreur lors de la lecture du localStorage pour la clé "${key}":`, error);
       return initialValue;
     }
   }, [key, initialValue]);

--- a/src/hooks/useStocks.ts
+++ b/src/hooks/useStocks.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { CreateStockData, SearchFilters, Stock, UpdateStockData } from '@/types';
-import { calculateStockStatus } from '@/types/stock'; // 🆕 AJOUTÉ
+import { calculateStockStatus } from '@/types/stock';
 import { createFrontendError, useAsyncAction, useLocalStorageState } from './useFrontendState';
 import { stockData } from '@/data/stockData.ts';
+import { logger } from '@/utils/logger';
 import { STOCK_MAX_THRESHOLD_DEFAULT, STOCK_MIN_THRESHOLD_DEFAULT } from '@/constants/stock';
 
 export type { CreateStockData, UpdateStockData };
@@ -108,7 +109,7 @@ export const useStocks = () => {
     ),
     {
       onSuccess: () => {
-        console.log('✅ Stock créé avec succès');
+        logger.info('Stock créé avec succès');
       },
       simulateDelay: 0,
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/index.css';
+import { logger } from '@/utils/logger';
 
 // Importer UNIQUEMENT les CSS tokens (variables CSS) - Critique pour le rendu
 import '@stockhub/design-system/dist/tokens/design-tokens.css';
@@ -11,7 +12,7 @@ import '@stockhub/design-system/dist/tokens/design-tokens.css';
 setTimeout(() => {
   // @ts-expect-error - Le Design System n'a pas de fichier .d.ts, mais fonctionne en runtime
   import('@stockhub/design-system').catch(err => {
-    console.error('❌ Erreur lors du chargement du Design System:', err);
+    logger.error('Erreur lors du chargement du Design System:', err);
   });
 }, 100); // Délai de 100ms pour laisser React charger d'abord
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import { useStocks } from '@/hooks/useStocks';
 import { useDataExport } from '@/hooks/useFrontendState';
 import { useTheme } from '@/hooks/useTheme.ts';
 import { generateAISuggestions } from '@/utils/aiPredictions';
+import { logger } from '@/utils/logger';
 
 export const Dashboard: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -68,7 +69,7 @@ export const Dashboard: React.FC = () => {
           setIsLoaded(true);
         }
       } catch (error) {
-        console.error('Erreur lors du chargement:', error);
+        logger.error('Erreur lors du chargement:', error);
       }
     };
 
@@ -99,7 +100,7 @@ export const Dashboard: React.FC = () => {
 
     const success = await exportToCsv(stocksForExport, 'stocks-export.csv');
     if (success) {
-      console.log('Export réussi');
+      logger.info('Export réussi');
     }
   }, [stocks, exportToCsv]);
 
@@ -112,7 +113,7 @@ export const Dashboard: React.FC = () => {
     });
 
     if (result) {
-      console.log('Stock créé:', result);
+      logger.info('Stock créé:', result);
     }
   }, [createStock]);
 
@@ -138,7 +139,7 @@ export const Dashboard: React.FC = () => {
 
   const handleViewStock = useCallback(
     (stockId: number | string): void => {
-      console.log('Voir détails:', getStockById(stockId));
+      logger.debug('Voir détails:', getStockById(stockId));
     },
     [getStockById]
   );
@@ -234,7 +235,7 @@ export const Dashboard: React.FC = () => {
               variant="secondary"
               icon={Search}
               aria-label="Ouvrir la page de recherche avancée de stocks"
-              onClick={() => console.log('🔍 Recherche avancée')}
+              onClick={() => logger.debug('Recherche avancée')}
             >
               <span className="hidden md:hidden lg:inline">Recherche Avancée</span>
             </Button>

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,20 @@
+/**
+ * Logger utilitaire pour StockHub V2
+ *
+ * En production (import.meta.env.PROD) : seuls warn et error s'affichent
+ * En développement : tous les niveaux s'affichent (debug, info, warn, error)
+ *
+ * Interface identique à console : logger.info(), logger.warn(), logger.error(), logger.debug()
+ */
+
+const noop: (...args: unknown[]) => void = () => {};
+
+const isProd = import.meta.env.PROD;
+
+export const logger = {
+  debug: isProd ? noop : console.debug.bind(console),
+  info: isProd ? noop : console.info.bind(console),
+  log: isProd ? noop : console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+};

--- a/src/utils/mlSimulation.ts
+++ b/src/utils/mlSimulation.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Stock } from '@/types/stock';
+import { logger } from '@/utils/logger';
 
 /**
  * Historical data point for time-series analysis
@@ -394,7 +395,7 @@ export function predictStockRupture(stock: Stock): StockPrediction {
 
   // Debug: Log regression for critical/low stocks
   if (stock.status === 'critical' || stock.status === 'low') {
-    console.log(`📊 ${stock.label}:`, {
+    logger.debug(`${stock.label}:`, {
       status: stock.status,
       quantity: stock.quantity,
       slope: regression.slope.toFixed(2),
@@ -408,7 +409,7 @@ export function predictStockRupture(stock: Stock): StockPrediction {
 
   // Debug: Log prediction result
   if (stock.status === 'critical' || stock.status === 'low') {
-    console.log(`  → daysUntilRupture: ${daysUntilRupture}`);
+    logger.debug(`  → daysUntilRupture: ${daysUntilRupture}`);
   }
 
   // Step 4: Calculate confidence intervals
@@ -478,7 +479,7 @@ export function predictStockRuptures(stocks: Stock[]): StockPrediction[] {
         return predictStockRupture(stock);
       } catch (error) {
         // If prediction fails (e.g., insufficient data), return a safe default
-        console.warn(`Failed to predict stock ${stock.id}:`, error);
+        logger.warn(`Failed to predict stock ${stock.id}:`, error);
         return null;
       }
     })


### PR DESCRIPTION
## 🔗 Issue liée

Closes #84

## 📋 Description

Création d'un logger utilitaire (`src/utils/logger.ts`) qui remplace tous les `console.log/warn/error` du code source. En production, seuls `warn` et `error` s'affichent. En développement, tous les niveaux sont actifs.

## 🧪 Type de changement

- [ ] ✨ Nouvelle fonctionnalité (US)
- [ ] 🐛 Correction de bug
- [x] ♻️ Refactoring / amélioration
- [ ] 📚 Documentation
- [ ] ⚙️ CI/CD / Config
- [ ] 🎨 Design System

## 🔧 Détails d'implémentation

### Logger (`src/utils/logger.ts`)
- Niveaux : `debug`, `info`, `log`, `warn`, `error`
- Basé sur `import.meta.env.PROD` (tree-shakeable par Vite)
- Interface identique à `console` : `logger.info()`, `logger.warn()`, etc.
- En production : `debug`, `info`, `log` → noop silencieux
- En production : `warn`, `error` → console.warn/error (toujours visibles)

### Fichiers modifiés (8 fichiers source)

| Fichier | console.log/warn/error remplacés |
|---|---|
| `pages/Dashboard.tsx` | 5 (log×3, error×1, debug×1) |
| `components/layout/HeaderWrapper.tsx` | 2 (debug×2) |
| `components/ai/AIAlertBannerWrapper.tsx` | 1 (debug×1) |
| `components/dashboard/StockCardWrapper.tsx` | 2 (info×1, error×1) |
| `hooks/useStocks.ts` | 1 (info×1) |
| `hooks/useFrontendState.ts` | 1 (warn×1) |
| `utils/mlSimulation.ts` | 3 (debug×2, warn×1) |
| `main.tsx` | 1 (error×1) |

### Tests adaptés (3 fichiers)
- `HeaderWrapper.test.tsx` : `vi.spyOn(console, 'log')` → `vi.spyOn(loggerModule.logger, 'debug')`
- `AIAlertBannerWrapper.test.tsx` : idem
- `useFrontendState.test.tsx` : `vi.spyOn(console, 'warn')` → `vi.spyOn(loggerModule.logger, 'warn')`

### Vérification
```
grep -r "^\s*console\." src/ --include="*.ts" --include="*.tsx" → 0 résultat
```
Seuls les JSDoc comments et fichiers de test contiennent encore `console.`

## ✅ Checklist

- [x] `npm run ci:check` passant (qualité + tests + build)
- [x] Couverture de tests maintenue (75.1%, pas de régression)
- [ ] Accessibilité vérifiée si changement UI (navigation clavier, ARIA) — N/A
- [ ] Lighthouse score non dégradé si changement UI — N/A
- [x] Documentation mise à jour si nécessaire — N/A (utilitaire interne)
- [x] GitHub Project mis à jour — #84 fermé

## 📸 Screenshots

N/A — changement interne, aucun impact UI.