### PR TITLE
feat(css): container queries (@container) and :has() for StockGrid (#76)

### DIFF
--- a/src/components/dashboard/StockGrid.tsx
+++ b/src/components/dashboard/StockGrid.tsx
@@ -15,37 +15,39 @@ export const StockGrid: React.FC<StockGridProps> = ({
   aiSuggestions = [],
 }) => {
   return (
-    <motion.section
-      className={`grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 ${className}`}
-      role="region"
-      aria-labelledby="stocks-list-heading"
-      layout
-    >
-      <h3 id="stocks-list-heading" className="sr-only">
-        Liste des stocks ({stocks.length} éléments)
-      </h3>
+    <div className="stock-grid-container">
+      <motion.section
+        className={`stock-grid ${className}`}
+        role="region"
+        aria-labelledby="stocks-list-heading"
+        layout
+      >
+        <h3 id="stocks-list-heading" className="sr-only">
+          Liste des stocks ({stocks.length} éléments)
+        </h3>
 
-      {stocks.map((stock, index) => {
-        // Filtrer les suggestions IA pour ce stock spécifique
-        const stockSuggestions = aiSuggestions.filter(
-          suggestion => suggestion.stockId === stock.id
-        );
+        {stocks.map((stock, index) => {
+          // Filtrer les suggestions IA pour ce stock spécifique
+          const stockSuggestions = aiSuggestions.filter(
+            suggestion => suggestion.stockId === stock.id
+          );
 
-        return (
-          <StockCardWrapper
-            key={stock.id}
-            stock={stock}
-            index={index}
-            isLoaded={isLoaded}
-            {...(onView && { onView })}
-            {...(onEdit && { onEdit })}
-            {...(onDelete && { onDelete })}
-            isUpdating={isUpdating}
-            isDeleting={isDeleting}
-            aiSuggestions={stockSuggestions}
-          />
-        );
-      })}
-    </motion.section>
+          return (
+            <StockCardWrapper
+              key={stock.id}
+              stock={stock}
+              index={index}
+              isLoaded={isLoaded}
+              {...(onView && { onView })}
+              {...(onEdit && { onEdit })}
+              {...(onDelete && { onDelete })}
+              isUpdating={isUpdating}
+              isDeleting={isDeleting}
+              aiSuggestions={stockSuggestions}
+            />
+          );
+        })}
+      </motion.section>
+    </div>
   );
 };

--- a/src/components/dashboard/__tests__/StockGrid.test.tsx
+++ b/src/components/dashboard/__tests__/StockGrid.test.tsx
@@ -19,16 +19,22 @@ describe('StockGrid Component', () => {
         expect(section).toBeInTheDocument();
       });
 
-      it('should apply responsive grid layout classes', () => {
+      it('should apply container-query grid class on section', () => {
         const stocks = [stockHubStockUseCases.optimalStock];
         const { container } = render(<StockGrid stocks={stocks} />);
 
+        // Responsive layout géré par @container CSS (stock-grid-container → stock-grid)
+        // plutôt que par les breakpoints viewport Tailwind (lg:, xl:)
         const section = container.querySelector('section');
-        expect(section).toHaveClass('grid');
-        expect(section).toHaveClass('grid-cols-1');
-        expect(section).toHaveClass('lg:grid-cols-2');
-        expect(section).toHaveClass('xl:grid-cols-3');
-        expect(section).toHaveClass('gap-6');
+        expect(section).toHaveClass('stock-grid');
+      });
+
+      it('should render inside a container-query wrapper', () => {
+        const stocks = [stockHubStockUseCases.optimalStock];
+        const { container } = render(<StockGrid stocks={stocks} />);
+
+        const wrapper = container.querySelector('.stock-grid-container');
+        expect(wrapper).toBeInTheDocument();
       });
 
       it('should display accessible hidden heading with count', () => {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -75,6 +75,60 @@ body {
   }
 }
 
+/* =================================================================
+   CSS MODERNE — Container Queries & :has()
+   Compatibilité : Chrome 105+ · Firefox 110/121+ · Safari 15.4/16+ ✅
+   ================================================================= */
+
+/* --- @container : StockGrid ---
+   @container utilisé ici plutôt que @media car StockGrid est réutilisé
+   dans des contextes de largeurs variables (dashboard, sidebar, modal futur).
+   Les breakpoints viewport (lg:, xl: Tailwind) ne reflètent pas la largeur
+   réelle du conteneur quand celui-ci est embarqué dans une colonne étroite. */
+
+.stock-grid-container {
+  container-type: inline-size;
+  container-name: stock-list;
+}
+
+.stock-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem; /* équivalent Tailwind gap-6 */
+}
+
+@container stock-list (min-width: 560px) {
+  .stock-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@container stock-list (min-width: 900px) {
+  .stock-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* --- :has() : Mise en évidence visuelle des stocks en alerte ---
+   :has() utilisé pour styler le conteneur parent en fonction du statut
+   de ses enfants (Web Components sh-stock-card), sans JavaScript.
+   Le CSS détecte l'attribut [status] posé sur l'élément custom et
+   applique un outline discret au niveau de la grille.
+   Avantage vs JS : zéro re-render React, déclaratif, toujours synchrone. */
+
+.stock-grid-container:has(sh-stock-card[status='critical']),
+.stock-grid-container:has(sh-stock-card[status='out-of-stock']) {
+  outline: 1px solid rgb(239 68 68 / 0.3);
+  outline-offset: 6px;
+  border-radius: 0.75rem;
+}
+
+.stock-grid-container:has(sh-stock-card[status='low']) {
+  outline: 1px solid rgb(234 179 8 / 0.3);
+  outline-offset: 6px;
+  border-radius: 0.75rem;
+}
+
 /* Scrollbar personnalisé — utilise les tokens du Design System */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Résumé

- `@container` sur `StockGrid` : layout responsive basé sur la largeur du conteneur, pas du viewport
- `:has()` sur `.stock-grid-container` : outline visuel automatique quand des stocks critiques/faibles sont présents
- Test mis à jour : vérifie `.stock-grid-container` et la classe `.stock-grid`
- Wiki : ADR-010 ajouté + section CSS moderne dans Frontend-Guide

## Changements

### `src/styles/index.css`

```css
/* @container — grille responsive selon la largeur du conteneur */
.stock-grid-container {
  container-type: inline-size;
  container-name: stock-list;
}
@container stock-list (min-width: 560px) { /* 2 colonnes */ }
@container stock-list (min-width: 900px) { /* 3 colonnes */ }

/* :has() — outline si stocks critiques/low présents */
.stock-grid-container:has(sh-stock-card[status='critical']) { outline: 1px solid rgb(239 68 68 / 0.3); }
.stock-grid-container:has(sh-stock-card[status='low'])      { outline: 1px solid rgb(234 179 8  / 0.3); }
```

### `src/components/dashboard/StockGrid.tsx`

- Ajout d'un `<div className="stock-grid-container">` wrapper
- `motion.section` : `grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6` → `stock-grid`

### `src/components/dashboard/__tests__/StockGrid.test.tsx`

- Test remplacé : vérifie `stock-grid` (CSS class) et présence du wrapper `.stock-grid-container`

## Choix d'implémentation

**@container plutôt que @media** : les breakpoints viewport Tailwind (`lg:`, `xl:`) fonctionnent sur le Dashboard mais échoueraient si `StockGrid` est embarqué dans un conteneur plus étroit (sidebar, modal). `@container` répond à la largeur réelle du conteneur.

**:has() plutôt que state React** : aucun re-render, déclaratif, synchrone avec le DOM. Le CSS lit l'attribut `[status]` posé par React sur `<sh-stock-card>` directement.

**CSS natif plutôt que plugin Tailwind** : `tailwindcss-container-queries` ajoute une dépendance pour ce que fait le CSS natif depuis 2022.

## Compatibilité

| Feature | Chrome | Firefox | Safari |
|---|---|---|---|
| `@container` | 105+ | 110+ | 16+ |
| `:has()` | 105+ | 121+ | 15.4+ |

## Test plan

- [ ] Dashboard : la grille passe à 2 colonnes quand le conteneur atteint ~560px
- [ ] Dashboard : la grille passe à 3 colonnes quand le conteneur atteint ~900px
- [ ] Stocks critiques présents → outline rouge discret autour de la grille
- [ ] Stocks faibles → outline jaune discret
- [ ] Aucune alerte → pas d'outline
- [ ] `npm run test:run` → 378 tests passent

Closes #76