### PR TITLE
feat(ci): add Azure SWA deployment workflow for V2 prod

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -15,6 +15,9 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     name: 🏗️ Build and Deploy
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: 📥 Checkout
@@ -67,6 +70,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: 🧹 Close Pull Request
+    permissions: {}
     steps:
       - name: Close Pull Request
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
## Ce qui a été fait

- Ajout `.github/workflows/azure-static-web-apps-deploy.yml` — déploiement automatique sur Azure Static Web Apps
- Adapté depuis le workflow V1 (`stockhub_front`) avec les améliorations V2 (Node 20, actions@v4, toutes les variables VITE_*)
- 10 secrets GitHub configurés (B2C + API URL prod + token Azure SWA)

## Workflow

| Déclencheur | Action |
|---|---|
| Push sur `main` | Build + Tests + Deploy prod Azure SWA |
| PR sur `main` | Build + Tests + Preview deployment Azure |
| PR fermée | Nettoyage preview |

## Variables injectées au build

Toutes les variables `VITE_*` sont injectées depuis les secrets GitHub — aucune valeur en clair dans le workflow.

## ⚠️ Prérequis avant merge

1. Déconnecter le repo V1 (`stockhub_front`) de la ressource Azure SWA dans Azure Portal
2. Ajouter la redirect URI prod dans Azure AD B2C : `https://brave-field-03611eb03.5.azurestaticapps.net/`

## Closes #93 (Correction 2)