### PR TITLE
fix(auth): migrate MSAL cache to sessionStorage and remove dead localStorage cleanup

### DIFF
--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -38,17 +38,8 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
     }
   };
 
-  // Fonction de nettoyage du localStorage (identique à V1)
-  const clearLocalStorage = () => {
-    localStorage.removeItem('msal.idtoken');
-    localStorage.removeItem('msal.accesstoken');
-    localStorage.removeItem('authToken'); // Notre token custom V2
-  };
-
-  // Fonction handleLogout (identique à V1 avec ajout de authToken)
   const handleLogout = useCallback(() => {
     logger.debug('Logout clicked');
-    clearLocalStorage();
     instance.logoutRedirect({ postLogoutRedirectUri: '/' })?.catch((err: unknown) => {
       logger.error('Erreur lors du logout:', err);
     });

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -31,7 +31,7 @@ export const msalConfig: Configuration = {
     postLogoutRedirectUri: window.location.origin,
   },
   cache: {
-    cacheLocation: 'localStorage',
+    cacheLocation: 'sessionStorage',
     storeAuthStateInCookie: false,
   },
   system: {


### PR DESCRIPTION
Closes #84

## Summary
- `src/config/authConfig.ts` : `cacheLocation` passé de `'localStorage'` à `'sessionStorage'` — les tokens MSAL ne persistent plus après fermeture de l'onglet et ne sont plus accessibles par d'autres onglets
- `src/components/layout/HeaderWrapper.tsx` : suppression de `clearLocalStorage()` — nettoyait des clés MSAL v1 (`msal.idtoken`, `msal.accesstoken`) qui n'existent plus en MSAL v4, et `authToken` qui n'est jamais écrit dans le code actuel

## Impact sécurité
`localStorage` → `sessionStorage` réduit la surface d'attaque XSS : un token volé ne survit plus à la fermeture de l'onglet.

## Test plan
- [x] `npm run ci:quality` — 0 erreur TypeScript, 0 erreur ESLint
- [x] `npm run test:run` — 380 passed, 0 failed
- [x] Pre-push hook (tests + build) — ✅
- [x] Test manuel login/logout sur l'app (sessionStorage à vérifier dans DevTools)