### PR TITLE
feat(stocks): StockFormModal create + edit — closes #98

### DIFF
--- a/src/components/stocks/StockFormModal.tsx
+++ b/src/components/stocks/StockFormModal.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { StockFormModalProps } from '@/types';
+import { ButtonWrapper } from '@/components/common/ButtonWrapper';
+import { StocksAPI } from '@/services/api/stocksAPI';
+
+export const StockFormModal: React.FC<StockFormModalProps> = ({
+  mode,
+  stock,
+  onSuccess,
+  onClose,
+}) => {
+  const [label, setLabel] = useState(stock?.label ?? '');
+  const [description, setDescription] = useState(stock?.description ?? '');
+  const [category, setCategory] = useState(stock?.category ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const handleSubmit = async () => {
+    if (!label.trim()) {
+      setError('Le nom du stock est requis.');
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      if (mode === 'create') {
+        await StocksAPI.createStock({
+          label: label.trim(),
+          description,
+          category,
+          quantity: 0,
+          value: 0,
+        });
+      } else {
+        await StocksAPI.updateStock({
+          id: stock!.id,
+          label: label.trim(),
+          description,
+          category,
+        });
+      }
+      onSuccess();
+      onClose();
+    } catch {
+      setError('Une erreur est survenue. Veuillez réessayer.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const title = mode === 'create' ? 'Nouveau stock' : 'Modifier le stock';
+  const submitLabel = mode === 'create' ? 'Créer' : 'Enregistrer';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="stock-form-title"
+        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6"
+      >
+        <h2 id="stock-form-title" className="text-xl font-bold mb-6 text-gray-900 dark:text-white">
+          {title}
+        </h2>
+
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="stock-label"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Nom du stock <span aria-hidden="true">*</span>
+            </label>
+            <input
+              id="stock-label"
+              ref={firstInputRef}
+              type="text"
+              value={label}
+              onChange={e => setLabel(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+              aria-required="true"
+              aria-invalid={error && !label.trim() ? 'true' : undefined}
+              aria-describedby={error && !label.trim() ? 'stock-form-error' : undefined}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="stock-description"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Description
+            </label>
+            <input
+              id="stock-description"
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="stock-category"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Catégorie
+            </label>
+            <input
+              id="stock-category"
+              type="text"
+              value={category}
+              onChange={e => setCategory(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+
+          {error && (
+            <p id="stock-form-error" role="alert" className="text-sm text-red-500">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 mt-6">
+          <ButtonWrapper variant="ghost" onClick={onClose} disabled={isSubmitting}>
+            Annuler
+          </ButtonWrapper>
+          <ButtonWrapper
+            variant="primary"
+            onClick={handleSubmit}
+            loading={isSubmitting}
+            disabled={isSubmitting}
+          >
+            {submitLabel}
+          </ButtonWrapper>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/stocks/__tests__/StockFormModal.test.tsx
+++ b/src/components/stocks/__tests__/StockFormModal.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StockFormModal } from '../StockFormModal';
+import { StocksAPI } from '@/services/api/stocksAPI';
+import { createMockStock } from '@/test/fixtures/stock';
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+vi.mock('@/services/api/stocksAPI', () => ({
+  StocksAPI: {
+    createStock: vi.fn(),
+    updateStock: vi.fn(),
+  },
+}));
+
+const mockOnSuccess = vi.fn();
+const mockOnClose = vi.fn();
+
+const editStock = {
+  id: 1,
+  label: 'Stock Test',
+  description: 'Description test',
+  category: 'alimentaire',
+};
+
+describe('StockFormModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when mode is create', () => {
+    it('should render with empty fields and "Nouveau stock" title', () => {
+      render(<StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />);
+
+      expect(screen.getByRole('heading', { name: 'Nouveau stock' })).toBeInTheDocument();
+      expect(screen.getByLabelText(/Nom du stock/)).toHaveValue('');
+      expect(screen.getByLabelText('Description')).toHaveValue('');
+      expect(screen.getByLabelText('Catégorie')).toHaveValue('');
+    });
+
+    it('should show error when label is empty on submit', async () => {
+      const { container } = render(
+        <StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Le nom du stock est requis.');
+      });
+      expect(StocksAPI.createStock).not.toHaveBeenCalled();
+    });
+
+    it('should call createStock and onSuccess on valid submit', async () => {
+      vi.mocked(StocksAPI.createStock).mockResolvedValueOnce(createMockStock());
+      const { container } = render(
+        <StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Nom du stock/), {
+        target: { value: 'Mon Nouveau Stock' },
+      });
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'Une description' },
+      });
+      fireEvent.change(screen.getByLabelText('Catégorie'), { target: { value: 'alimentation' } });
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(StocksAPI.createStock).toHaveBeenCalledWith({
+          label: 'Mon Nouveau Stock',
+          description: 'Une description',
+          category: 'alimentation',
+          quantity: 0,
+          value: 0,
+        });
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should call onClose on cancel', () => {
+      const { container } = render(
+        <StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      const cancelButton = container.querySelector('sh-button[variant="ghost"]');
+      cancelButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show loading state during submission', async () => {
+      let resolveCreate!: () => void;
+      vi.mocked(StocksAPI.createStock).mockReturnValue(
+        new Promise(resolve => {
+          resolveCreate = () => resolve(createMockStock());
+        })
+      );
+
+      const { container } = render(
+        <StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Nom du stock/), { target: { value: 'Test' } });
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(submitButton?.hasAttribute('loading')).toBe(true);
+        expect(submitButton?.hasAttribute('disabled')).toBe(true);
+      });
+
+      resolveCreate();
+    });
+
+    it('should show error message on API failure', async () => {
+      vi.mocked(StocksAPI.createStock).mockRejectedValueOnce(new Error('API error'));
+      const { container } = render(
+        <StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Nom du stock/), { target: { value: 'Test' } });
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Une erreur est survenue.');
+      });
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when mode is edit', () => {
+    it('should render with pre-filled fields and "Modifier le stock" title', () => {
+      render(
+        <StockFormModal
+          mode="edit"
+          stock={editStock}
+          onSuccess={mockOnSuccess}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByRole('heading', { name: 'Modifier le stock' })).toBeInTheDocument();
+      expect(screen.getByLabelText(/Nom du stock/)).toHaveValue('Stock Test');
+      expect(screen.getByLabelText('Description')).toHaveValue('Description test');
+      expect(screen.getByLabelText('Catégorie')).toHaveValue('alimentaire');
+    });
+
+    it('should call updateStock with stock id on valid submit', async () => {
+      vi.mocked(StocksAPI.updateStock).mockResolvedValueOnce(createMockStock());
+      const { container } = render(
+        <StockFormModal
+          mode="edit"
+          stock={editStock}
+          onSuccess={mockOnSuccess}
+          onClose={mockOnClose}
+        />
+      );
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(StocksAPI.updateStock).toHaveBeenCalledWith({
+          id: 1,
+          label: 'Stock Test',
+          description: 'Description test',
+          category: 'alimentaire',
+        });
+        expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should not call updateStock when label is cleared', async () => {
+      const { container } = render(
+        <StockFormModal
+          mode="edit"
+          stock={editStock}
+          onSuccess={mockOnSuccess}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Nom du stock/), { target: { value: '' } });
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(StocksAPI.updateStock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should close on Escape key', () => {
+      render(<StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have role=dialog and aria-modal', () => {
+      render(<StockFormModal mode="create" onSuccess={mockOnSuccess} onClose={mockOnClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+  });
+});

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BarChart3, Download, Plus, Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import type { Stock } from '@/types';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
@@ -11,6 +12,7 @@ import { AIAlertBannerWrapper as AISummaryWidget } from '@/components/ai/AIAlert
 import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
 import { SearchInputWrapper } from '@/components/common/SearchInputWrapper';
 import { CardWrapper } from '@/components/common/CardWrapper';
+import { StockFormModal } from '@/components/stocks/StockFormModal';
 
 import { useStocks } from '@/hooks/useStocks';
 import { useDataExport } from '@/hooks/useFrontendState';
@@ -21,6 +23,8 @@ import { logger } from '@/utils/logger';
 export const Dashboard: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [isFormOpen, setIsFormOpen] = useState<boolean>(false);
+  const [editingStock, setEditingStock] = useState<Stock | null>(null);
 
   const navigate = useNavigate();
   const { theme } = useTheme();
@@ -29,8 +33,6 @@ export const Dashboard: React.FC = () => {
     stocks,
     stats,
     loadStocks,
-    createStock,
-    updateStock,
     deleteStock,
     updateFilters,
     resetFilters,
@@ -105,18 +107,9 @@ export const Dashboard: React.FC = () => {
     }
   }, [stocks, exportToCsv]);
 
-  const handleCreateStock = useCallback(async (): Promise<void> => {
-    const result = await createStock({
-      label: 'Nouveau Stock',
-      quantity: 50,
-      value: 1000,
-      description: 'Stock créé depuis le dashboard',
-    });
-
-    if (result) {
-      logger.info('Stock créé:', result);
-    }
-  }, [createStock]);
+  const handleCreateStock = useCallback(() => {
+    setIsFormOpen(true);
+  }, []);
 
   const handleDeleteStock = useCallback(
     async (stockId: number | string): Promise<void> => {
@@ -126,17 +119,14 @@ export const Dashboard: React.FC = () => {
   );
 
   const handleUpdateStock = useCallback(
-    async (stockId: number | string): Promise<void> => {
-      const currentStock = getStockById(stockId);
-      if (currentStock) {
-        await updateStock({
-          id: stockId,
-          quantity: (currentStock.quantity ?? 0) + 10,
-        });
-        await loadStocks();
+    (stockId: number | string) => {
+      const stock = getStockById(stockId);
+      if (stock) {
+        setEditingStock(stock);
+        setIsFormOpen(true);
       }
     },
-    [getStockById, updateStock, loadStocks]
+    [getStockById]
   );
 
   const handleViewStock = useCallback(
@@ -215,7 +205,6 @@ export const Dashboard: React.FC = () => {
               variant="primary"
               icon={Plus}
               onClick={handleCreateStock}
-              loading={isLoading.create}
               aria-label="Ajouter un nouveau stock à l'inventaire"
               className="w-auto max-w-[150px]"
             >
@@ -344,8 +333,6 @@ export const Dashboard: React.FC = () => {
               />
               <span className={themeClasses.textMuted}>
                 {isLoading.load && 'Chargement des stocks...'}
-                {isLoading.create && 'Création en cours...'}
-                {isLoading.update && 'Mise à jour...'}
                 {isLoading.delete && 'Suppression...'}
               </span>
             </div>
@@ -381,7 +368,6 @@ export const Dashboard: React.FC = () => {
                 variant="primary"
                 icon={Plus}
                 onClick={handleCreateStock}
-                loading={isLoading.create}
                 className="lg:hidden"
                 aria-label="Ajouter un stock"
               >
@@ -398,6 +384,21 @@ export const Dashboard: React.FC = () => {
       </main>
 
       <FooterWrapper />
+
+      {isFormOpen && (
+        <StockFormModal
+          mode={editingStock ? 'edit' : 'create'}
+          stock={editingStock ?? undefined}
+          onSuccess={() => {
+            void loadStocks();
+            setEditingStock(null);
+          }}
+          onClose={() => {
+            setIsFormOpen(false);
+            setEditingStock(null);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -160,15 +160,7 @@ describe('Dashboard Component', () => {
 
   describe('User interactions', () => {
     describe('when user clicks Add Stock button', () => {
-      it('should call createStock with fixture data', async () => {
-        const mockCreateStock = vi.fn();
-
-        vi.mocked(useStocksModule.useStocks).mockReturnValue(
-          createMockUseStocks({
-            createStock: mockCreateStock,
-          })
-        );
-
+      it('should open the stock form modal', async () => {
         const { container } = await act(async () => {
           return renderDashboard();
         });
@@ -181,7 +173,10 @@ describe('Dashboard Component', () => {
           addButton!.dispatchEvent(new CustomEvent('sh-button-click', { bubbles: true }));
         });
 
-        expect(mockCreateStock).toHaveBeenCalled();
+        // Modal should be open with the create form
+        const dialog = container.querySelector('[role="dialog"]');
+        expect(dialog).toBeInTheDocument();
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
       });
     });
 

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -72,3 +72,17 @@ export interface StockGridProps {
   className?: string;
   aiSuggestions?: AISuggestion[];
 }
+
+export type StockFormMode = 'create' | 'edit';
+
+export interface StockFormModalProps {
+  mode: StockFormMode;
+  stock?: {
+    id: number | string;
+    label: string;
+    description?: string;
+    category?: string;
+  };
+  onSuccess: () => void;
+  onClose: () => void;
+}


### PR DESCRIPTION
## Summary

- Add `StockFormModal` component supporting **create** and **edit** modes
- Dashboard "Ajouter un Stock" button now opens the modal (replaces hardcoded stock creation)
- `onEdit` from `StockGrid` opens the modal pre-filled with the existing stock data
- `StockFormMode` and `StockFormModalProps` types added to `src/types/components.ts`

## Technical details

- Uses `ButtonWrapper` (sh-button WC) and HTML `<input>` + Tailwind (no InputWrapper in project)
- Calls `StocksAPI.createStock` / `StocksAPI.updateStock` directly; `onSuccess` triggers `loadStocks()` in the parent
- Accessible: `role="dialog"`, `aria-modal="true"`, focus on first field on mount, Escape closes modal
- 11 tests: create mode (validation, API call, cancel, loading state, API error) + edit mode (pre-fill, updateStock, cleared label) + accessibility (Escape, aria-modal)

## Test plan

- [x] `npm run type-check` → 0 errors
- [x] `npm run lint` → 0 errors in src
- [x] `npm run test:run` → 391 passed, 0 failed
- [x] `npm run build` → build OK
- [x] Manual: create stock via modal, edit stock via modal, cancel, Escape key, API error simulation

Closes #98