### PR TITLE
fix(a11y): bump DS to v1.3.2, fix label-content-name-mismatch — closes #125

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@azure/msal-browser": "^4.27.0",
         "@azure/msal-react": "^3.0.23",
-        "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.1",
+        "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.2",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.517.0",
         "react": "19.2.3",
@@ -2323,8 +2323,8 @@
       }
     },
     "node_modules/@stockhub/design-system": {
-      "version": "1.3.1",
-      "resolved": "git+ssh://git@github.com/SandrineCipolla/stockhub_design_system.git#2cfea08598a034cd3e3a55bce47ba99f4d8e7cd3",
+      "version": "1.3.2",
+      "resolved": "git+ssh://git@github.com/SandrineCipolla/stockhub_design_system.git#c0ac828ba0c47ddbcc25c69a77da9065b44197ce",
       "license": "ISC",
       "dependencies": {
         "color-contrast-checker": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@azure/msal-browser": "^4.27.0",
     "@azure/msal-react": "^3.0.23",
-    "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.1",
+    "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.2",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.517.0",
     "react": "19.2.3",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -205,7 +205,7 @@ export const Dashboard: React.FC = () => {
               variant="primary"
               icon={Plus}
               onClick={handleCreateStock}
-              aria-label="Ajouter un nouveau stock à l'inventaire"
+              aria-label="Ajouter un Stock à l'inventaire"
               className="w-auto max-w-[150px]"
             >
               <span className="hidden md:hidden lg:inline">Ajouter un Stock</span>
@@ -213,7 +213,7 @@ export const Dashboard: React.FC = () => {
             <Button
               variant="secondary"
               icon={BarChart3}
-              aria-label="Voir les analyses IA et prédictions ML"
+              aria-label="Analyses IA et prédictions ML"
               onClick={() => navigate('/analytics')}
               className="w-auto max-w-[150px]"
             >
@@ -222,7 +222,7 @@ export const Dashboard: React.FC = () => {
             <Button
               variant="secondary"
               icon={Search}
-              aria-label="Ouvrir la page de recherche avancée de stocks"
+              aria-label="Recherche Avancée de stocks"
               onClick={() => logger.debug('Recherche avancée')}
             >
               <span className="hidden md:hidden lg:inline">Recherche Avancée</span>


### PR DESCRIPTION
## Summary

- Bump `@stockhub/design-system` `v1.3.1` → `v1.3.2` (fix propagation `aria-label` dans `sh-button`)
- Correction des `aria-label` non conformes WCAG 2.5.3 dans `Dashboard.tsx` : chaque label contient désormais le texte visible du bouton

## Fichiers modifiés

- `package.json` / `package-lock.json`
- `src/pages/Dashboard.tsx`

## Test plan

- [x] 485 tests passent
- [ ] Lighthouse `label-content-name-mismatch` ne signale plus d'erreur
- [ ] Score accessibilité Lighthouse ≥ 95/100

Closes #125