### PR TITLE
fix(auth): wait for MSAL init before redirecting on protected routes — closes #132

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { useIsAuthenticated } from '@azure/msal-react';
+import { useIsAuthenticated, useMsal } from '@azure/msal-react';
+import { InteractionStatus } from '@azure/msal-browser';
 import { ThemeProvider } from '@/components/providers/ThemeProvider.tsx';
 import { CookieBanner } from '@/components/common/CookieBanner';
 import './styles/index.css';
@@ -41,9 +42,12 @@ const LoadingFallback = () => (
   </main>
 );
 
-// Protège les routes authentifiées — redirige vers / si non connecté
+// Protège les routes authentifiées — attend la fin de l'init MSAL avant de rediriger
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useIsAuthenticated();
+  const { inProgress } = useMsal();
+
+  if (inProgress !== InteractionStatus.None) return <LoadingFallback />;
   if (!isAuthenticated) return <Navigate to="/" replace />;
   return <>{children}</>;
 }


### PR DESCRIPTION
## 🔗 Issue liée

Closes #132

## 📋 Description

Au refresh sur `/stocks/:id`, MSAL n'a pas encore fini de restaurer la session. `useIsAuthenticated()` retourne `false` momentanément → `ProtectedRoute` redirige vers `/` → redirect vers `/dashboard`. L'utilisateur perd sa navigation.

## 🔧 Détails d'implémentation

**Couche impactée :** `src/App.tsx` — `ProtectedRoute`

- Ajout de `useMsal` pour lire `inProgress`
- Si MSAL est en cours d'initialisation (`inProgress !== InteractionStatus.None`), affiche `LoadingFallback` au lieu de rediriger
- La redirection vers `/` n'a lieu que lorsque MSAL a confirmé que l'utilisateur n'est pas authentifié

## 🧪 Type de changement

- [x] 🐛 Correction de bug (fix)

## ✅ Checklist

- [x] 526 tests passent
- [x] TypeScript 0 erreurs
- [x] ESLint 0 warnings