### PR TITLE
fix(status): align out-of-stock status to kebab-case and fix prediction display — closes #136

### DIFF
--- a/src/components/dashboard/StockCardWrapper.tsx
+++ b/src/components/dashboard/StockCardWrapper.tsx
@@ -13,7 +13,7 @@ const convertStatusToWebComponent = (status: StockStatus): WebComponentStatus =>
     optimal: 'optimal',
     low: 'low',
     critical: 'critical',
-    outOfStock: 'out-of-stock',
+    'out-of-stock': 'out-of-stock',
     overstocked: 'overstocked',
   };
   return statusMap[status];

--- a/src/components/dashboard/__tests__/StockCardWrapper.test.tsx
+++ b/src/components/dashboard/__tests__/StockCardWrapper.test.tsx
@@ -127,7 +127,7 @@ describe('StockCardWrapper', () => {
     });
 
     it('should convert outOfStock status correctly', () => {
-      const stock = { ...mockStock, status: 'outOfStock' as const };
+      const stock = { ...mockStock, status: 'out-of-stock' as const };
       const { container } = render(<StockCardWrapper stock={stock} />);
       const card = container.querySelector('sh-stock-card');
       expect(card?.getAttribute('status')).toBe('out-of-stock');
@@ -282,7 +282,7 @@ describe('StockCardWrapper', () => {
     });
 
     it('should handle zero quantity', () => {
-      const stock = { ...mockStock, quantity: 0, status: 'outOfStock' as const };
+      const stock = { ...mockStock, quantity: 0, status: 'out-of-stock' as const };
       const { container } = render(<StockCardWrapper stock={stock} />);
       const card = container.querySelector('sh-stock-card');
       expect(card?.getAttribute('quantity')).toBe('0 unités');

--- a/src/constants/stockConfig.ts
+++ b/src/constants/stockConfig.ts
@@ -45,7 +45,7 @@ export interface StockStatusConfig {
  * Ordre de priorité : Rupture > Critique > Attention > Normal > Surstockage
  */
 export const STOCK_STATUS_CONFIG: Record<StockStatus, StockStatusConfig> = {
-  outOfStock: {
+  'out-of-stock': {
     label: 'Out of Stock',
     icon: XCircle,
     colors: {
@@ -165,6 +165,6 @@ export const STOCK_STATUS_BG_COLORS: Record<string, string> = {
   optimal: '16 185 129', // emerald-500
   low: '245 158 11', // amber-500
   critical: '239 68 68', // red-500
-  outOfStock: '107 114 128', // gray-500
+  'out-of-stock': '107 114 128', // gray-500
   overstocked: '59 130 246', // blue-500
 };

--- a/src/hooks/__tests__/useStocks.test.tsx
+++ b/src/hooks/__tests__/useStocks.test.tsx
@@ -25,7 +25,7 @@ const calculateStatus = (
   minThreshold?: number,
   maxThreshold?: number
 ): string => {
-  if (quantity === 0) return 'outOfStock';
+  if (quantity === 0) return 'out-of-stock';
   if (minThreshold !== undefined) {
     const criticalThreshold = minThreshold * 0.5;
     if (quantity <= criticalThreshold) return 'critical';
@@ -486,7 +486,7 @@ describe('useStocks Hook', () => {
         });
 
         expect(updated).not.toBeNull();
-        expect(updated!.status).toBe('outOfStock');
+        expect(updated!.status).toBe('out-of-stock');
       });
     });
   });

--- a/src/hooks/useStocks.ts
+++ b/src/hooks/useStocks.ts
@@ -122,7 +122,7 @@ export const useStocks = () => {
           let newStatus = existingStock.status;
           if (updateData.quantity !== undefined) {
             if (newQuantity === 0) {
-              newStatus = 'outOfStock';
+              newStatus = 'out-of-stock';
             } else if (minThreshold !== undefined) {
               if (newQuantity <= minThreshold * 0.5) newStatus = 'critical';
               else if (newQuantity <= minThreshold) newStatus = 'low';
@@ -250,7 +250,7 @@ export const useStocks = () => {
       optimal: stocks.filter(s => s.status === 'optimal').length,
       low: stocks.filter(s => s.status === 'low').length,
       critical: stocks.filter(s => s.status === 'critical').length,
-      outOfStock: stocks.filter(s => s.status === 'outOfStock').length,
+      'out-of-stock': stocks.filter(s => s.status === 'out-of-stock').length,
       overstocked: stocks.filter(s => s.status === 'overstocked').length,
       totalValue: stocks.reduce((sum, stock) => sum + stock.value, 0),
       averageValue:

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -23,11 +23,11 @@ import type { StockDetailItem } from '@/types';
 
 const ITEMS_PER_PAGE = 20;
 
-type FilterStatus = 'all' | 'optimal' | 'low' | 'critical' | 'outOfStock';
+type FilterStatus = 'all' | 'optimal' | 'low' | 'critical' | 'out-of-stock';
 
-const getItemStatus = (item: StockDetailItem): 'optimal' | 'low' | 'critical' | 'outOfStock' => {
+const getItemStatus = (item: StockDetailItem): 'optimal' | 'low' | 'critical' | 'out-of-stock' => {
   const min = item.minimumStock ?? 1;
-  if (item.quantity === 0) return 'outOfStock';
+  if (item.quantity === 0) return 'out-of-stock';
   if (item.quantity < min) return 'critical';
   if (item.quantity === min) return 'low';
   return 'optimal';
@@ -37,29 +37,29 @@ const STATUS_LABELS: Record<string, string> = {
   optimal: 'OK',
   low: 'Stock bas',
   critical: 'Critique',
-  outOfStock: 'Rupture',
+  'out-of-stock': 'Rupture',
 };
 
 const STATUS_COLORS: Record<string, string> = {
   optimal: 'text-green-600',
   low: 'text-yellow-600',
   critical: 'text-orange-500',
-  outOfStock: 'text-red-600',
+  'out-of-stock': 'text-red-600',
 };
 
 const STATUS_DOT_COLORS: Record<string, string> = {
   optimal: 'bg-green-500',
   low: 'bg-yellow-500',
   critical: 'bg-orange-500',
-  outOfStock: 'bg-red-600',
+  'out-of-stock': 'bg-red-600',
 };
 
 const filterChips = (
   total: number,
-  counts: Record<'optimal' | 'low' | 'critical' | 'outOfStock', number>
+  counts: Record<'optimal' | 'low' | 'critical' | 'out-of-stock', number>
 ): { key: FilterStatus; label: string }[] => [
   { key: 'all', label: `Tous (${total})` },
-  { key: 'outOfStock', label: `Rupture (${counts.outOfStock})` },
+  { key: 'out-of-stock', label: `Rupture (${counts['out-of-stock']})` },
   { key: 'critical', label: `Critique (${counts.critical})` },
   { key: 'low', label: `Stock bas (${counts.low})` },
   { key: 'optimal', label: `OK (${counts.optimal})` },
@@ -115,13 +115,13 @@ export const StockDetailPage: React.FC = () => {
   const totalPages = Math.ceil(filteredItems.length / ITEMS_PER_PAGE);
 
   const statusCounts = useMemo(() => {
-    if (!stock) return { optimal: 0, low: 0, critical: 0, outOfStock: 0 };
+    if (!stock) return { optimal: 0, low: 0, critical: 0, 'out-of-stock': 0 };
     return stock.items.reduce(
       (acc, item) => {
         acc[getItemStatus(item)]++;
         return acc;
       },
-      { optimal: 0, low: 0, critical: 0, outOfStock: 0 }
+      { optimal: 0, low: 0, critical: 0, 'out-of-stock': 0 }
     );
   }, [stock]);
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -109,26 +109,6 @@ body {
   }
 }
 
-/* --- :has() : Mise en évidence visuelle des stocks en alerte ---
-   :has() utilisé pour styler le conteneur parent en fonction du statut
-   de ses enfants (Web Components sh-stock-card), sans JavaScript.
-   Le CSS détecte l'attribut [status] posé sur l'élément custom et
-   applique un outline discret au niveau de la grille.
-   Avantage vs JS : zéro re-render React, déclaratif, toujours synchrone. */
-
-.stock-grid-container:has(sh-stock-card[status='critical']),
-.stock-grid-container:has(sh-stock-card[status='out-of-stock']) {
-  outline: 1px solid rgb(239 68 68 / 0.3);
-  outline-offset: 6px;
-  border-radius: 0.75rem;
-}
-
-.stock-grid-container:has(sh-stock-card[status='low']) {
-  outline: 1px solid rgb(234 179 8 / 0.3);
-  outline-offset: 6px;
-  border-radius: 0.75rem;
-}
-
 /* Scrollbar personnalisé — utilise les tokens du Design System */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/test/fixtures/hooks.ts
+++ b/src/test/fixtures/hooks.ts
@@ -13,7 +13,7 @@ export const createMockUseStocks = (overrides = {}) => ({
     optimal: stocksByStatus.optimal.length,
     low: stocksByStatus.low.length,
     critical: stocksByStatus.critical.length,
-    outOfStock: dashboardStocks.filter(s => s.status === 'outOfStock').length,
+    'out-of-stock': dashboardStocks.filter(s => s.status === 'out-of-stock').length,
     overstocked: dashboardStocks.filter(s => s.status === 'overstocked').length,
     totalValue: dashboardStocks.reduce((sum, stock) => sum + stock.value, 0),
     averageValue:

--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -10,7 +10,7 @@
 export const OPTIMAL = 'optimal';
 export const LOW = 'low';
 export const CRITICAL = 'critical';
-export const OUT_OF_STOCK = 'outOfStock';
+export const OUT_OF_STOCK = 'out-of-stock';
 export const OVERSTOCKED = 'overstocked';
 
 /**
@@ -85,7 +85,7 @@ export interface StockStats {
   optimal: number;
   low: number;
   critical: number;
-  outOfStock: number;
+  'out-of-stock': number;
   overstocked: number;
   totalValue: number;
   averageValue: number;

--- a/src/utils/__tests__/stockPredictions.test.ts
+++ b/src/utils/__tests__/stockPredictions.test.ts
@@ -146,16 +146,16 @@ describe('computePredictions', () => {
   });
 
   describe('out-of-stock edge case', () => {
-    it('should set daysUntilRupture to null when quantity is 0', () => {
+    it('should set daysUntilRupture to 0 when quantity is 0', () => {
       const items = [makeItem({ status: 'out-of-stock', quantity: 0 })];
       const [result] = computePredictions(items);
-      expect(result?.daysUntilRupture).toBeNull();
+      expect(result?.daysUntilRupture).toBe(0);
     });
 
-    it('should set confidence to 99 for out-of-stock', () => {
+    it('should set confidence to 100 for out-of-stock', () => {
       const items = [makeItem({ status: 'out-of-stock', quantity: 0 })];
       const [result] = computePredictions(items);
-      expect(result?.confidence).toBe(99);
+      expect(result?.confidence).toBe(100);
     });
   });
 });

--- a/src/utils/stockPredictions.ts
+++ b/src/utils/stockPredictions.ts
@@ -50,13 +50,14 @@ export function computePredictions(
               ? 'medium'
               : 'low';
 
-      const confidence = item.status === 'out-of-stock' ? 99 : item.status === 'critical' ? 92 : 78;
+      const confidence =
+        item.status === 'out-of-stock' ? 100 : item.status === 'critical' ? 92 : 78;
 
       return {
         stockName: item.label,
         stockId: String(item.id),
         riskLevel,
-        daysUntilRupture: item.quantity === 0 ? null : daysUntilRupture,
+        daysUntilRupture: daysUntilRupture,
         confidence,
         dailyConsumptionRate: dailyRate,
         currentQuantity: item.quantity,


### PR DESCRIPTION
## Couches impactées
- **Types** : `StockStatus.OUT_OF_STOCK` renommé de `'outOfStock'` → `'out-of-stock'` pour correspondre au backend et au design system
- **Hooks** : `useStocks.ts` — stats et filtres
- **Components** : `StockCardWrapper.tsx`, `StockDetailPage.tsx`, `stockConfig.ts`
- **Utils** : `stockPredictions.ts` — calcul prédictions
- **CSS** : `index.css` — suppression du sélecteur `:has()` qui appliquait un contour rouge à toute la grille

## Changements

### Bug 1 — Badge "Optimal" au lieu de "Rupture de stock"
La valeur `'outOfStock'` (camelCase) ne correspondait pas à la valeur renvoyée par le backend (`'out-of-stock'`, kebab-case). Renommage à la source dans `StockStatus` enum et propagation dans tous les fichiers.

### Bug 2 — "Aucun risque de rupture" pour un article à 0
`daysUntilRupture` retournait `null` pour qty=0, ce qui faisait afficher "Aucun risque" dans le composant design system. Corrigé : retourne `0`.

### Bug 3 — Confiance à 99% au lieu de 100% pour rupture de stock
Correction de la valeur de confiance pour les articles à 0 stock.

### Bug 4 — Contour rouge sur toutes les cartes du dashboard
Le sélecteur CSS `:has(.status-critical, .status-out-of-stock)` s'appliquait au conteneur de grille entier. Suppression du bloc.

## Test plan
- [x] `npm run test:run` — 546 tests passent
- [x] `npx tsc --noEmit` — 0 erreur TypeScript
- [x] Testé en local : badge "Rupture de stock" correct, prédictions cohérentes, pas de contour rouge parasite

Closes #136