### PR TITLE
feat(items): display last update date column in item table — closes #157

### DIFF
--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -37,7 +37,8 @@ const formatRelativeDate = (isoDate: string | null | undefined): string => {
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return "Aujourd'hui";
+  if (diffDays === 0)
+    return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
   if (diffDays === 1) return 'Hier';
   if (diffDays < 30) return `Il y a ${diffDays} j`;
   return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -31,6 +31,18 @@ const ITEMS_PER_PAGE = 20;
 
 type FilterStatus = 'all' | 'optimal' | 'low' | 'critical' | 'out-of-stock';
 
+const formatRelativeDate = (isoDate: string | null | undefined): string => {
+  if (!isoDate) return '—';
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "Aujourd'hui";
+  if (diffDays === 1) return 'Hier';
+  if (diffDays < 30) return `Il y a ${diffDays} j`;
+  return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });
+};
+
 const getItemStatus = (item: StockDetailItem): 'optimal' | 'low' | 'critical' | 'out-of-stock' => {
   const min = item.minimumStock ?? 1;
   if (item.quantity === 0) return 'out-of-stock';
@@ -475,6 +487,9 @@ export const StockDetailPage: React.FC = () => {
                         <th className="text-left px-4 py-3 font-medium">Statut</th>
                         <th className="text-center px-4 py-3 font-medium">Quantité</th>
                         <th className="text-center px-4 py-3 font-medium">Min</th>
+                        <th className="text-center px-4 py-3 font-medium hidden sm:table-cell">
+                          Mise à jour
+                        </th>
                         {(myRole === 'OWNER' || myRole === 'EDITOR') && (
                           <th className="text-right px-4 py-3 font-medium">Actions</th>
                         )}
@@ -589,6 +604,11 @@ export const StockDetailPage: React.FC = () => {
                             </td>
                             <td className={`px-4 py-3 text-center ${themeClasses.textMuted}`}>
                               {item.minimumStock}
+                            </td>
+                            <td
+                              className={`px-4 py-3 text-center text-xs hidden sm:table-cell ${themeClasses.textMuted}`}
+                            >
+                              {formatRelativeDate(item.updatedAt)}
                             </td>
                             {(myRole === 'OWNER' || myRole === 'EDITOR') && (
                               <td className="px-4 py-3">

--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -199,6 +199,7 @@ export interface StockDetailItem {
   quantity: number;
   minimumStock?: number;
   status: ItemStatus;
+  updatedAt?: string | null;
 }
 
 export interface StockDetail {


### PR DESCRIPTION
## Modifications

- Ajout de `updatedAt?: string | null` dans le type `StockDetailItem`
- Ajout d'un helper `formatRelativeDate` : affiche l'heure (J+0), "Hier" (J+1), "Il y a X j" (J+2 à J+29), ou la date courte (J+30+)
- Ajout de la colonne "Mise à jour" dans le tableau des items de `StockDetailPage`, masquée sur mobile

## Plan de test
- [x] La colonne "Mise à jour" est visible sur desktop
- [x] La colonne est masquée sur mobile
- [x] Les items sans date affichent "—"
- [x] Un item modifié aujourd'hui affiche l'heure (ex. "14:32")
- [ ] Un item modifié hier affiche "Hier"
- [ ] Un item modifié il y a plusieurs jours affiche "Il y a X j"

Closes #157