### PR TITLE
fix(header): notification bell count + tooltip per stock — closes #171

### DIFF
--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useMsal, useIsAuthenticated } from '@azure/msal-react';
 import { useTheme } from '@/hooks/useTheme';
 import { loginRequest } from '@/config/authConfig';
@@ -12,8 +12,10 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   className = '',
   userName,
   notificationCount = 0,
+  notificationTooltip,
   isLoggedIn: isLoggedInProp,
 }) => {
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null);
   const { theme, toggleTheme } = useTheme();
   const { instance, accounts, inProgress } = useMsal();
   const isAuthenticated = useIsAuthenticated();
@@ -95,24 +97,82 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
       if (isLogoutButton) handleLogoutRef.current();
     };
 
+    const onShow = () => {
+      const rect = bellButton?.getBoundingClientRect();
+      if (rect) setTooltipPos({ top: rect.bottom + 6, left: rect.left + rect.width / 2 });
+    };
+    const onHide = () => setTooltipPos(null);
+
+    const headerEl = headerRef.current;
+    const bellButton = headerEl?.shadowRoot?.querySelector<HTMLElement>(
+      'button[title="Notifications"]'
+    );
+    bellButton?.addEventListener('mouseenter', onShow);
+    bellButton?.addEventListener('mouseleave', onHide);
+
+    // Sur mobile (pas de hover), toggle au tap via l'événement custom du DS
+    const onBellClick = () => {
+      setTooltipPos(prev => {
+        if (prev) return null;
+        const rect = bellButton?.getBoundingClientRect();
+        return rect ? { top: rect.bottom + 6, left: rect.left + rect.width / 2 } : null;
+      });
+    };
+
+    // Fermer le tooltip si on clique ailleurs
+    const onClickOutside = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Element) || !target.closest('sh-header')) setTooltipPos(null);
+    };
+
     document.addEventListener('sh-logout-click', onLogout);
     document.addEventListener('sh-button-click', onButtonClick);
+    document.addEventListener('sh-notification-click', onBellClick);
+    document.addEventListener('click', onClickOutside);
 
     return () => {
       document.removeEventListener('sh-logout-click', onLogout);
       document.removeEventListener('sh-button-click', onButtonClick);
+      document.removeEventListener('sh-notification-click', onBellClick);
+      document.removeEventListener('click', onClickOutside);
+      bellButton?.removeEventListener('mouseenter', onShow);
+      bellButton?.removeEventListener('mouseleave', onHide);
     };
   }, []);
 
-  return React.createElement('sh-header', {
-    ref: headerRef,
-    userName: resolvedUserName,
-    notificationCount,
-    'data-theme': theme,
-    className,
-    'onsh-notification-click': handleNotifications,
-    'onsh-theme-toggle': handleThemeToggle,
-    'onsh-login-click': handleLogin,
-    'onsh-logout-click': handleLogout,
-  });
+  return (
+    <div style={{ position: 'relative' }}>
+      {React.createElement('sh-header', {
+        ref: headerRef,
+        userName: resolvedUserName,
+        notificationCount,
+        'data-theme': theme,
+        className,
+        'onsh-notification-click': handleNotifications,
+        'onsh-theme-toggle': handleThemeToggle,
+        'onsh-login-click': handleLogin,
+        'onsh-logout-click': handleLogout,
+      })}
+      {notificationTooltip && notificationTooltip.length > 0 && tooltipPos && (
+        <div
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            top: tooltipPos.top,
+            left: tooltipPos.left,
+            transform: 'translateX(-50%)',
+          }}
+          className={`z-50 rounded-lg shadow-xl px-3 py-2 text-xs whitespace-nowrap pointer-events-none border ${
+            theme === 'dark'
+              ? 'bg-slate-800 text-gray-100 border-slate-600'
+              : 'bg-white text-gray-800 border-gray-200'
+          }`}
+        >
+          {notificationTooltip.map((line, i) => (
+            <div key={i}>{line}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };

--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -11,7 +11,7 @@ import type { HeaderProps } from '@/types';
 export const HeaderWrapper: React.FC<HeaderProps> = ({
   className = '',
   userName,
-  notificationCount = 3,
+  notificationCount = 0,
   isLoggedIn: isLoggedInProp,
 }) => {
   const { theme, toggleTheme } = useTheme();

--- a/src/components/layout/__tests__/HeaderWrapper.test.tsx
+++ b/src/components/layout/__tests__/HeaderWrapper.test.tsx
@@ -100,10 +100,10 @@ describe('HeaderWrapper', () => {
       expect(header?.getAttribute('username')).toBe('Test User');
     });
 
-    it('should use default notificationCount of 3', () => {
+    it('should use default notificationCount of 0', () => {
       const { container } = render(<HeaderWrapper />);
       const header = container.querySelector('sh-header');
-      expect(header?.getAttribute('notificationcount')).toBe('3');
+      expect(header?.getAttribute('notificationcount')).toBe('0');
     });
 
     it('should use empty string as default className', () => {

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -12,6 +12,7 @@ import { CardWrapper } from '@/components/common/CardWrapper';
 
 import { useStocks } from '@/hooks/useStocks';
 import { useTheme } from '@/hooks/useTheme';
+import { usePendingContributionsCount } from '@/hooks/usePendingContributionsCount';
 import { predictStockRuptures } from '@/utils/mlSimulation';
 
 type RiskFilter = 'all' | 'critical' | 'high' | 'medium' | 'low';
@@ -21,6 +22,7 @@ export const Analytics: React.FC = () => {
   const navigate = useNavigate();
   const { theme } = useTheme();
   const { stocks } = useStocks();
+  const { count: pendingCount } = usePendingContributionsCount();
 
   // Generate all ML predictions
   const allPredictions = useMemo(() => {
@@ -53,7 +55,7 @@ export const Analytics: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper />
+      <HeaderWrapper notificationCount={pendingCount} />
 
       {/* Navigation Section */}
       <NavSection>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -62,6 +62,14 @@ export const Dashboard: React.FC = () => {
 
   const notificationCount = pendingCount + stats.critical + stats['out-of-stock'];
 
+  const notificationTooltip: string[] = [
+    ...stocks.filter(s => s.status === 'critical').map(s => `🔴 ${s.label} — critique`),
+    ...stocks.filter(s => s.status === 'out-of-stock').map(s => `⚫ ${s.label} — rupture`),
+    ...(pendingCount > 0
+      ? [`🔔 ${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`]
+      : []),
+  ];
+
   // Classes CSS basées sur le thème
   const themeClasses = {
     background: theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50',
@@ -192,7 +200,10 @@ export const Dashboard: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={notificationCount} />
+      <HeaderWrapper
+        notificationCount={notificationCount}
+        notificationTooltip={notificationTooltip}
+      />
 
       {/* Navigation Section */}
       <NavSection>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -60,6 +60,8 @@ export const Dashboard: React.FC = () => {
     return generateAISuggestions(stocks);
   }, [stocks]);
 
+  const notificationCount = pendingCount + stats.critical + stats['out-of-stock'];
+
   // Classes CSS basées sur le thème
   const themeClasses = {
     background: theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50',
@@ -190,7 +192,7 @@ export const Dashboard: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={pendingCount} />
+      <HeaderWrapper notificationCount={notificationCount} />
 
       {/* Navigation Section */}
       <NavSection>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -62,13 +62,16 @@ export const Dashboard: React.FC = () => {
 
   const notificationCount = pendingCount + stats.critical + stats['out-of-stock'];
 
-  const notificationTooltip: string[] = [
-    ...stocks.filter(s => s.status === 'critical').map(s => `🔴 ${s.label} — critique`),
-    ...stocks.filter(s => s.status === 'out-of-stock').map(s => `⚫ ${s.label} — rupture`),
-    ...(pendingCount > 0
-      ? [`🔔 ${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`]
-      : []),
-  ];
+  const notificationTooltip = useMemo(
+    () => [
+      ...stocks.filter(s => s.status === 'critical').map(s => `🔴 ${s.label} — critique`),
+      ...stocks.filter(s => s.status === 'out-of-stock').map(s => `⚫ ${s.label} — rupture`),
+      ...(pendingCount > 0
+        ? [`🔔 ${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`]
+        : []),
+    ],
+    [stocks, pendingCount]
+  );
 
   // Classes CSS basées sur le thème
   const themeClasses = {

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -4,9 +4,11 @@ import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { NavSection } from '@/components/layout/NavSection';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
 import { useTheme } from '@/hooks/useTheme';
+import { usePendingContributionsCount } from '@/hooks/usePendingContributionsCount';
 
 export const Privacy: React.FC = () => {
   const { theme } = useTheme();
+  const { count: pendingCount } = usePendingContributionsCount();
 
   const themeClasses = {
     background: theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50',
@@ -20,7 +22,7 @@ export const Privacy: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper />
+      <HeaderWrapper notificationCount={pendingCount} />
 
       <NavSection
         breadcrumbs={[

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -56,6 +56,7 @@ export interface HeaderProps {
   className?: string;
   userName?: string;
   notificationCount?: number;
+  notificationTooltip?: string[];
   isLoggedIn?: boolean;
 }
 


### PR DESCRIPTION
## Résumé

- La cloche affichait toujours 0 même avec des stocks critiques/rupture et des contributions en attente
- Ajout d'un tooltip au survol (desktop) et au tap (mobile) listant les stocks concernés par nom

## Composants modifiés

- `src/pages/Dashboard.tsx` — calcul `notificationCount` (pendingCount + critical + out-of-stock) et construction du tableau `notificationTooltip`
- `src/components/layout/HeaderWrapper.tsx` — détection du bouton cloche via `shadowRoot.querySelector`, positionnement `fixed` via `getBoundingClientRect`, toggle mobile via `sh-notification-click`
- `src/types/dashboard.ts` — ajout de `notificationTooltip?: string[]` sur `HeaderProps`
- `src/pages/Analytics.tsx`, `src/pages/Privacy.tsx` — `notificationCount={pendingCount}`
- `src/components/layout/__tests__/HeaderWrapper.test.tsx` — correction valeur par défaut `notificationCount` (3 → 0)

## Test plan

- [ ] Se connecter avec des stocks critiques/rupture → la cloche affiche le bon chiffre
- [ ] Survoler la cloche (desktop) → tooltip positionné juste sous la cloche avec une ligne par stock
- [ ] Taper sur la cloche (mobile) → tooltip affiché/masqué au tap
- [ ] Cliquer ailleurs → tooltip se ferme
- [ ] Sans stock en alerte → cloche à 0, pas de tooltip

Closes #171