### PR TITLE
fix(landing): hide notification bell and fix copyright year for unauthenticated users — closes #138

### DIFF
--- a/src/components/layout/FooterWrapper.tsx
+++ b/src/components/layout/FooterWrapper.tsx
@@ -16,7 +16,7 @@ export const FooterWrapper: React.FC = () => {
     <>
       {React.createElement('sh-footer', {
         'app-name': 'STOCK HUB',
-        year: '2025',
+        year: String(new Date().getFullYear()),
         'data-theme': theme,
       })}
       <div className={`${bgClass} ${textClass} px-6 py-3 text-center text-xs`}>

--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -83,6 +83,23 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   }, [isLoggedIn]);
 
   useEffect(() => {
+    const shadowRoot = headerRef.current?.shadowRoot;
+    if (!shadowRoot) return;
+    const styleId = 'hide-notification-bell';
+    const existing = shadowRoot.querySelector(`#${styleId}`);
+    if (!isLoggedIn) {
+      if (!existing) {
+        const style = document.createElement('style');
+        style.id = styleId;
+        style.textContent = '.notification-btn { display: none !important; }';
+        shadowRoot.appendChild(style);
+      }
+    } else {
+      existing?.remove();
+    }
+  }, [isLoggedIn]);
+
+  useEffect(() => {
     const onLogout = () => handleLogoutRef.current();
 
     const onButtonClick = (e: Event) => {


### PR DESCRIPTION
## Résumé

- La cloche de notifications s'affichait sur la landing page alors que l'utilisateur n'est pas connecté
- L'année du copyright était codée en dur à 2025

## Composants modifiés

- `src/components/layout/HeaderWrapper.tsx` — injection d'un `<style>` dans le shadow root pour masquer `.notification-btn` quand `isLoggedIn=false` ; style retiré automatiquement si l'utilisateur se connecte
- `src/components/layout/FooterWrapper.tsx` — `year` remplacé par `new Date().getFullYear()`

## Test plan

- [x] Landing page (non connecté) → cloche absente du header
- [x] Dashboard (connecté) → cloche toujours visible avec le bon compteur
- [x] Footer → affiche 2026 sur toutes les pages

Closes #138