### PR TITLE
feat(search): normalize accents in stock search filter — closes #16

### DIFF
--- a/src/hooks/useStocks.ts
+++ b/src/hooks/useStocks.ts
@@ -235,8 +235,8 @@ export const useStocks = () => {
   const filteredStocks = useMemo(() => {
     return stocks.filter(stock => {
       if (filters.query) {
-        const query = filters.query.toLowerCase();
-        if (!stock.label.toLowerCase().includes(query)) {
+        const normalize = (s: string) => s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+        if (!normalize(stock.label).includes(normalize(filters.query))) {
           return false;
         }
       }

--- a/src/hooks/useStocks.ts
+++ b/src/hooks/useStocks.ts
@@ -222,16 +222,6 @@ export const useStocks = () => {
 
   // ===== COMPUTED VALUES =====
 
-  const ownedStocks = useMemo(
-    () => stocks.filter(s => !s.viewerRole || s.viewerRole === 'OWNER'),
-    [stocks]
-  );
-
-  const sharedStocks = useMemo(
-    () => stocks.filter(s => s.viewerRole && s.viewerRole !== 'OWNER'),
-    [stocks]
-  );
-
   const filteredStocks = useMemo(() => {
     return stocks.filter(stock => {
       if (filters.query) {
@@ -253,6 +243,16 @@ export const useStocks = () => {
       return !(filters.maxValue !== undefined && stock.value > filters.maxValue);
     });
   }, [stocks, filters]);
+
+  const ownedStocks = useMemo(
+    () => filteredStocks.filter(s => !s.viewerRole || s.viewerRole === 'OWNER'),
+    [filteredStocks]
+  );
+
+  const sharedStocks = useMemo(
+    () => filteredStocks.filter(s => s.viewerRole && s.viewerRole !== 'OWNER'),
+    [filteredStocks]
+  );
 
   const stats = useMemo(() => {
     return {


### PR DESCRIPTION
## Résumé

La recherche ne trouvait pas les stocks si l'utilisateur tapait sans accent (ex: "cafe" ne trouvait pas "Café").

## Composant modifié

- `src/hooks/useStocks.ts` — fonction `normalize` locale qui fait `toLowerCase` + `NFD` + suppression des diacritiques, appliquée sur le label et la query avant comparaison

## Test plan

- [x] Taper "cafe" → trouve "Café Arabica"
- [x] Taper "éléphant" → trouve "Éléphant"
- [x] Recherche normale sans accents → toujours fonctionnelle
- [x] Recherche vide → affiche tous les stocks

Closes #16