### PR TITLE
feat(stocks): display relative date on stock cards — closes #62

### DIFF
--- a/src/components/dashboard/StockCardWrapper.tsx
+++ b/src/components/dashboard/StockCardWrapper.tsx
@@ -6,6 +6,7 @@ import type { WebComponentStatus } from '@/types/web-component-events';
 import type { StockStatus, Stock } from '@/types/stock';
 import { formatQuantityWithUnit } from '@/utils/unitFormatter';
 import { recordUsage } from '@/utils/containerManager';
+import { formatRelativeDate } from '@/utils/dateUtils';
 
 // Conversion du format StockStatus vers le format du web component
 const convertStatusToWebComponent = (status: StockStatus): WebComponentStatus => {
@@ -104,7 +105,7 @@ export const StockCardWrapper: React.FC<StockCardProps> = ({
     id: `stock-card-${localStock.id}`,
     name: localStock.label,
     category: localStock.category || '',
-    'last-update': `Mis à jour il y a ${localStock.lastUpdate}`,
+    'last-update': `Mis à jour ${formatRelativeDate(localStock.lastUpdate)}`,
     percentage:
       localStock.unit === 'percentage' && localStock.quantity !== undefined
         ? localStock.quantity.toString()

--- a/src/components/dashboard/__tests__/StockCardWrapper.test.tsx
+++ b/src/components/dashboard/__tests__/StockCardWrapper.test.tsx
@@ -33,7 +33,7 @@ const mockStock: Stock = {
   value: 1500,
   unit: 'piece',
   status: 'optimal',
-  lastUpdate: '2 heures',
+  lastUpdate: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
   minThreshold: 20,
   maxThreshold: 200,
 };
@@ -187,17 +187,25 @@ describe('StockCardWrapper', () => {
   });
 
   describe('Last update formatting', () => {
-    it('should format last update text', () => {
+    it('should format last update text with relative date', () => {
       const { container } = render(<StockCardWrapper stock={mockStock} />);
       const card = container.querySelector('sh-stock-card');
-      expect(card?.getAttribute('last-update')).toBe('Mis à jour il y a 2 heures');
+      expect(card?.getAttribute('last-update')).toBe('Mis à jour Il y a 5 j');
     });
 
-    it('should handle different time formats', () => {
-      const stock = { ...mockStock, lastUpdate: 'maintenant' };
+    it('should show "Hier" for yesterday', () => {
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const stock = { ...mockStock, lastUpdate: yesterday };
       const { container } = render(<StockCardWrapper stock={stock} />);
       const card = container.querySelector('sh-stock-card');
-      expect(card?.getAttribute('last-update')).toBe('Mis à jour il y a maintenant');
+      expect(card?.getAttribute('last-update')).toBe('Mis à jour Hier');
+    });
+
+    it('should show "—" for invalid date', () => {
+      const stock = { ...mockStock, lastUpdate: 'invalid' };
+      const { container } = render(<StockCardWrapper stock={stock} />);
+      const card = container.querySelector('sh-stock-card');
+      expect(card?.getAttribute('last-update')).toBe('Mis à jour —');
     });
   });
 

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit, Pencil, Plus, Trash2, Users } from 'lucide-react';
+import { formatRelativeDate } from '@/utils/dateUtils';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
@@ -30,19 +31,6 @@ import type { StockDetailItem } from '@/types';
 const ITEMS_PER_PAGE = 20;
 
 type FilterStatus = 'all' | 'optimal' | 'low' | 'critical' | 'out-of-stock';
-
-const formatRelativeDate = (isoDate: string | null | undefined): string => {
-  if (!isoDate) return '—';
-  const date = new Date(isoDate);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0)
-    return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
-  if (diffDays === 1) return 'Hier';
-  if (diffDays < 30) return `Il y a ${diffDays} j`;
-  return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });
-};
 
 const getItemStatus = (item: StockDetailItem): 'optimal' | 'low' | 'critical' | 'out-of-stock' => {
   const min = item.minimumStock ?? 1;

--- a/src/services/api/stocksAPI.ts
+++ b/src/services/api/stocksAPI.ts
@@ -51,6 +51,7 @@ interface BackendStock {
   status?: StockStatus;
   items?: BackendItem[];
   viewerRole?: string;
+  updatedAt?: string;
 }
 
 /**
@@ -85,7 +86,7 @@ function mapBackendStockToFrontend(backendStock: BackendStock): Stock {
     quantity: backendStock.totalQuantity ?? fallback.quantity,
     value: 0,
     status: backendStock.status ?? fallback.status,
-    lastUpdate: new Date().toISOString(),
+    lastUpdate: backendStock.updatedAt ?? new Date().toISOString(),
     unit: 'piece',
     viewerRole: backendStock.viewerRole,
   };

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,13 @@
+export const formatRelativeDate = (isoDate: string | null | undefined): string => {
+  if (!isoDate) return '—';
+  const date = new Date(isoDate);
+  if (isNaN(date.getTime())) return '—';
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0)
+    return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  if (diffDays === 1) return 'Hier';
+  if (diffDays < 30) return `Il y a ${diffDays} j`;
+  return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' });
+};


### PR DESCRIPTION
## Résumé

Les cartes stocks affichaient la date ISO brute. Elles affichent maintenant une date lisible et relative.

## Logique d'affichage

| Écart | Affichage |
|-------|-----------|
| Aujourd'hui | `14:30` (heure) |
| Hier | `Hier` |
| < 30 jours | `Il y a X j` |
| ≥ 30 jours | `12 juin` |
| Date invalide / absente | `—` |

## Composants modifiés

- `src/utils/dateUtils.ts` — utilitaire partagé `formatRelativeDate`
- `src/components/dashboard/StockCardWrapper.tsx` — utilise `formatRelativeDate` pour `last-update`
- `src/pages/StockDetailPage.tsx` — migré vers `dateUtils` (suppression du doublon local)
- `src/services/api/stocksAPI.ts` — ajout de `updatedAt?` sur `BackendStock`, utilisé en priorité sur `new Date()` (ticket backend #228)
- `src/components/dashboard/__tests__/StockCardWrapper.test.tsx` — tests mis à jour avec ISO dates

## Note

Les dates seront toutes identiques tant que le backend ne retourne pas `updatedAt` sur `/api/v2/stocks`. Ticket backend créé : SandrineCipolla/stockhub_back#228.

Closes #62