### PR TITLE
fix(header): resolve username from MSAL cache on page refresh — closes #172

### DIFF
--- a/ETAT-DU-PROJET.md
+++ b/ETAT-DU-PROJET.md
@@ -1,17 +1,57 @@
 # StockHub V2 Frontend — État du projet
 
-**Date de rédaction** : 12 juin 2026
-**Dernière activité** : 5 avril 2026 (mise en standby depuis ~2 mois)
-**Branche active** : `feat/157-item-last-updated` (commits déjà mergés dans main)
-**Version publiée** : v1.12.0 · package.json : 1.11.0 (Release Please à merger)
+**Date de rédaction** : 13 juin 2026
+**Dernière activité** : 13 juin 2026 (session de reprise active)
+**Branche active** : `fix/172-username-after-refresh` (PR #177 ouverte, en attente de merge)
+**Version publiée** : v1.12.1 (Release Please a mergé automatiquement)
+
+---
+
+## Session du 12–13 juin 2026 — Ce qui a été fait
+
+### Tickets fermés
+
+| #    | Titre                                               | PR      |
+| ---- | --------------------------------------------------- | ------- |
+| #171 | Cloche notifications : compteur + tooltip par stock | #173 ✅ |
+| #138 | Masquer cloche landing + corriger copyright year    | #174 ✅ |
+| #16  | Normalisation accents dans la recherche             | #175 ✅ |
+| #62  | Date relative sur les cartes stocks ("Il y a X j")  | #176 ✅ |
+
+### Bug corrigé en cours (#175)
+
+La recherche ne filtrait pas les cartes stocks — `ownedStocks` et `sharedStocks` étaient dérivés de `stocks` brut au lieu de `filteredStocks`. Corrigé dans `useStocks.ts`.
+
+### Nouveau fichier utilitaire
+
+`src/utils/dateUtils.ts` — `formatRelativeDate()` partagée entre `StockCardWrapper` et `StockDetailPage`.
+
+### Tickets créés
+
+| #        | Repo  | Titre                                                           | Board       |
+| -------- | ----- | --------------------------------------------------------------- | ----------- |
+| #170     | Front | Rechercher un item par nom depuis le dashboard (bloqué backend) | Backlog     |
+| #172     | Front | Username "utilisateur" après F5                                 | In Progress |
+| DS#39    | DS    | Supprimer attributs `title` natifs sur boutons sh-header        | Backlog DS  |
+| Back#228 | Back  | Exposer `updatedAt` sur GET /api/v2/stocks                      | Backlog     |
+
+### CI optimisé
+
+Le workflow "Quality Audits" (Lighthouse, axe-core, bundle) saute les PRs Dependabot et Release Please.
+
+---
+
+## PR en attente de merge
+
+| PR   | Branche                          | Sujet                                  |
+| ---- | -------------------------------- | -------------------------------------- |
+| #177 | `fix/172-username-after-refresh` | Username après F5 (localStorage cache) |
 
 ---
 
 ## Où en est l'application
 
 ### Ce qui tourne en production
-
-L'application est **déployée et fonctionnelle** sur deux environnements :
 
 | Env        | URL                                    | Backend              |
 | ---------- | -------------------------------------- | -------------------- |
@@ -22,39 +62,22 @@ L'application est **déployée et fonctionnelle** sur deux environnements :
 
 ### Fonctionnalités livrées (résumé par release)
 
-**v1.12.0 — 5 avril 2026** _(dernière release)_
+**Session 12–13 juin 2026** _(à venir dans prochaine release)_
+
+- Cloche notifications : compteur réel (critique + rupture + contributions) + tooltip par stock au survol
+- Cloche masquée sur la landing page (non connecté)
+- Copyright year dynamique dans le footer
+- Recherche stocks avec normalisation des accents
+- Recherche stocks filtre bien les cartes (fix ownedStocks/sharedStocks)
+- Date relative sur les cartes stocks ("Il y a 5 j", "Hier", "14:30")
+- Username après F5 : lu depuis localStorage en attendant MSAL
+
+**v1.12.1 — mai 2026**
 
 - Colonne "dernière mise à jour" dans le tableau des items (affiche l'heure si aujourd'hui)
 - Compteur réel de contributions en attente sur la cloche du header
 - Layout responsive amélioré (mobile)
 - Bannière "lecture seule" et carte cliquable pour le rôle VIEWER
-- Fix : refresh automatique du stock après approbation/rejet d'une contribution
-
-**v1.11.0 — 5 avril 2026**
-
-- Dashboard groupé par rôle : "Mes stocks" / "Partagés avec moi"
-- Sections repliables sur le dashboard
-
-**v1.10.0 — 31 mars 2026**
-
-- Fix status kebab-case + affichage prédictions
-- Fix badge statut stock (utilisait maintenant les données backend agrégées)
-- Fix authentification : refresh sur `/stocks/:id` ne redirige plus vers dashboard
-
-**v1.9.0 — 25 mars 2026**
-
-- Optimisation SEO/GEO landing page
-- Fix aria-label non conformes WCAG 2.5.3
-
-**v1.8.0 — 16 mars 2026**
-
-- Couverture de tests étendue (useItems, useStockDetail, itemsAPI)
-
-**v1.7.0 — v1.6.0 (mars 2026)**
-
-- Collaboration complète : gestion collaborateurs, workflow contribution (suggérer → approuver/rejeter)
-- Prédictions IA branchées sur les vrais endpoints backend
-- Distinction suggestions LLM vs déterministes
 
 ---
 
@@ -63,7 +86,7 @@ L'application est **déployée et fonctionnelle** sur deux environnements :
 ```
 React 19.1  ·  TypeScript 5.8.3 strict  ·  Vite 6.3.5
 TailwindCSS 3.4.1  ·  Framer Motion  ·  Lucide React
-React Router DOM 7.9.5  ·  MSAL (Azure AD B2C)
+React Router DOM 7.9.5  ·  MSAL (Azure AD B2C, sessionStorage)
 Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 ```
 
@@ -71,49 +94,58 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 **Métriques qualité actuelles**
 
+- Tests : **547 tests** (~60% coverage)
+- Bundle : 113 KB gzipped
 - Lighthouse Performance : **99/100**
 - Lighthouse Accessibility : **96/100**
-- EcoIndex : **A (88.42)**
-- Tests : **~464 tests** (~60% coverage)
-- Bundle : 113 KB gzipped
 
 ---
 
 ## Backlog — ce qui reste à faire
 
+### PR à merger en priorité
+
+| PR   | Sujet                       |
+| ---- | --------------------------- |
+| #177 | Username après F5 (fix/172) |
+
 ### Bugs ouverts
 
-| #    | Titre                                                                             | Priorité |
-| ---- | --------------------------------------------------------------------------------- | -------- |
-| #138 | Masquer la cloche et corriger copyright pour utilisateurs non connectés (landing) | —        |
-| #30  | Comportement `optionalDependencies` Vercel à investiguer                          | P1       |
+| #    | Titre                                                    | Priorité           |
+| ---- | -------------------------------------------------------- | ------------------ |
+| #172 | Username "utilisateur" après F5                          | En cours (PR #177) |
+| #30  | Comportement `optionalDependencies` Vercel à investiguer | P1                 |
+
+### Design System — à faire dans stockhub_design_system
+
+| #     | Titre                                                                               | Priorité |
+| ----- | ----------------------------------------------------------------------------------- | -------- |
+| DS#39 | Supprimer attributs `title` natifs sur boutons sh-header (cloche, thème, connexion) | P2       |
+
+### Backend — à faire dans stockhub_back
+
+| #        | Titre                                      | Priorité |
+| -------- | ------------------------------------------ | -------- |
+| Back#228 | Exposer `updatedAt` sur GET /api/v2/stocks | P3       |
 
 ### P1 — Bloquants / Critiques
 
-| #    | Titre                                                            |
-| ---- | ---------------------------------------------------------------- |
-| #66  | Tests E2E complets Frontend + Backend                            |
-| #101 | Auth interactive Playwright pour tests E2E                       |
-| #51  | Accessibilité : améliorer score de 86 à 95+ (4 issues critiques) |
+| #    | Titre                                                |
+| ---- | ---------------------------------------------------- |
+| #66  | Tests E2E complets Frontend + Backend                |
+| #101 | Auth interactive Playwright pour tests E2E           |
+| #51  | Accessibilité : améliorer score (4 issues critiques) |
 
 ### Features planifiées (par priorité d'intérêt)
 
-| #    | Titre                                                            | Nature                 |
-| ---- | ---------------------------------------------------------------- | ---------------------- |
-| #165 | Afficher les items d'un stock en cards sur mobile                | UX mobile              |
-| #163 | Panneau de notifications avec alertes contextuelles              | Feature (front + back) |
-| #145 | Shopping list UI — générer, afficher, exporter                   | Feature IA             |
-| #144 | Input catégorie custom avec suggestions autocomplete             | UX                     |
-| #143 | Gestion et filtrage des tags libres sur les articles             | Feature                |
-| #142 | Afficher et éditer la note libre d'un article                    | Feature                |
-| #141 | Bibliothèque projets sauvegardés (liste + détail + étapes)       | Feature IA             |
-| #140 | Page liste d'approvisionnement — générée, éditable, partageable  | Feature IA             |
-| #139 | Page "Que faire avec ce que j'ai ?" + SuggestionCard + TutoModal | Feature IA             |
-| #122 | Permettre à l'utilisateur de créer ses propres catégories        | UX                     |
-| #121 | Aperçus visuels dans les cartes fonctionnalités de la landing    | UX                     |
-| #16  | Normalisation des accents dans la recherche                      | Quick win              |
-| #61  | Modal de confirmation avant suppression d'un stock avec items    | UX                     |
-| #62  | Affichage "il y a X temps" pour lastUpdate                       | Quick win              |
+| #    | Titre                                                         | Nature                   |
+| ---- | ------------------------------------------------------------- | ------------------------ |
+| #165 | Afficher les items d'un stock en cards sur mobile             | UX mobile                |
+| #163 | Panneau de notifications avec alertes contextuelles           | Feature (front + back)   |
+| #170 | Rechercher un item par nom depuis le dashboard                | Feature (bloqué backend) |
+| #145 | Shopping list UI — générer, afficher, exporter                | Feature IA               |
+| #144 | Input catégorie custom avec suggestions autocomplete          | UX                       |
+| #61  | Modal de confirmation avant suppression d'un stock avec items | UX                       |
 
 ### Dette technique
 
@@ -127,12 +159,11 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 ### Documentation / RNCP
 
-| #   | Titre                                             |
-| --- | ------------------------------------------------- |
-| #90 | Veille technologique formelle (RNCP CE2.3.1)      |
-| #43 | Synchroniser RNCP-CHECKLIST.md                    |
-| #4  | RNCP Checklist suivi global                       |
-| #25 | Harmoniser structure docs avec design system repo |
+| #   | Titre                                        |
+| --- | -------------------------------------------- |
+| #90 | Veille technologique formelle (RNCP CE2.3.1) |
+| #43 | Synchroniser RNCP-CHECKLIST.md               |
+| #4  | RNCP Checklist suivi global                  |
 
 ---
 
@@ -147,30 +178,27 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 | Bloc 3     | Mise en production          | ~10% — GitHub Actions, tests automatisés, monitoring à construire     |
 | Bloc 4     | Management d'équipe         | 0% — simulation à préparer (RACI, fiches de poste, métriques)         |
 
-**Phase RNCP actuelle** : Phase 2 "Migration & Intégration" (Jan–Mai 2026) — légèrement en retard.
-Les livrables en attente pour cette phase : tests automatisés >80% coverage, pipeline CI/CD complet.
-
 ---
 
-## Prochaines étapes recommandées pour reprendre
+## Pour demain — par où commencer
 
-### Court terme (reprendre l'élan)
+### 1. Merger PR #177 (5 min)
 
-1. **Merger la PR Release Please** — package.json est encore à 1.11.0 alors que la dernière release est v1.12.0
-2. **Quick wins** — #138 (cloche landing), #16 (accents recherche), #62 (date relative) : chacun < 1h
-3. **Bug P1** — #30 (Vercel optionalDependencies) à investiguer avant prochaine mise en prod
+Vérifier CI vert et merger `fix/172-username-after-refresh`.
 
-### Moyen terme (valeur fonctionnelle)
+### 2. Design System DS#39 (30–60 min)
 
-4. **#165** — Cards items sur mobile (suite logique du responsive v1.12.0)
-5. **#163** — Panneau notifications (infrastructure déjà posée avec la cloche)
-6. **#145/#140** — Shopping list (feature à forte valeur, roadmap Phase 3)
+Supprimer les attributs `title` natifs sur les boutons `sh-header` (cloche, thème, connexion) dans le repo `stockhub_design_system`. Republier le package et mettre à jour la dépendance dans le front.
 
-### RNCP (certification)
+> C'est la correction propre du tooltip "Notifications" qu'on a contourné côté front dans `HeaderWrapper`.
 
-7. **#90** — Veille technologique : démarrer le fichier `VEILLE-TECHNOLOGIQUE.md`
-8. **#66/#101** — Tests E2E Playwright : indispensables pour Bloc 3
-9. **Diagrammes UML** : classes, séquence, composants (manquants pour Bloc 2 complet)
+### 3. Feature #165 — Items en cards sur mobile (1–2h)
+
+Suite logique du responsive. Les items sont en tableau, pas adapté au petit écran.
+
+### 4. Feature #163 — Panneau notifications (2–3h)
+
+L'infrastructure est posée (cloche avec compteur + tooltip). L'étape suivante est un panneau/drawer qui s'ouvre au clic sur la cloche.
 
 ---
 
@@ -184,3 +212,5 @@ Les livrables en attente pour cette phase : tests automatisés >80% coverage, pi
 | Staging                 | https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app/ |
 | Storybook Design System | https://68f5fbe10f495706cb168751-nufqfdjaoc.chromatic.com/                   |
 | Backend staging         | https://stockhub-back.onrender.com/api                                       |
+| DS repo                 | https://github.com/SandrineCipolla/stockhub_design_system                    |
+| Backend repo            | https://github.com/SandrineCipolla/stockhub_back                             |

--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -20,18 +20,22 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   const { instance, accounts, inProgress } = useMsal();
   const isAuthenticated = useIsAuthenticated();
 
-  // getAllAccounts() lit le cache MSAL de façon synchrone — disponible dès le premier render
-  // après F5, contrairement à accounts[] (état React) qui se peuple en différé.
   const account = instance.getActiveAccount() ?? instance.getAllAccounts()[0] ?? accounts[0];
   const emailClaim = account?.idTokenClaims?.['emails'];
   const emailFromToken =
     Array.isArray(emailClaim) && typeof emailClaim[0] === 'string' ? emailClaim[0] : undefined;
+
+  // Fallback localStorage : évite "Utilisateur" (défaut DS) le temps que MsalProvider
+  // finisse son initialisation (inProgress: 'startup' → 'none' avec accounts: []).
+  const CACHE_KEY = 'stockhub_username';
+  const cachedName = localStorage.getItem(CACHE_KEY) ?? undefined;
   const resolvedUserName =
     userName ??
     account?.idTokenClaims?.name ??
     account?.name ??
     emailFromToken ??
     account?.username ??
+    cachedName ??
     '';
 
   // Si isLoggedIn est passé en prop (ex: LandingPage force false), on l'utilise directement.
@@ -60,6 +64,7 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
 
   const handleLogout = useCallback(() => {
     logger.debug('Logout clicked');
+    localStorage.removeItem(CACHE_KEY);
     instance.logoutRedirect({ postLogoutRedirectUri: '/' })?.catch((err: unknown) => {
       logger.error('Erreur lors du logout:', err);
     });
@@ -77,6 +82,12 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   // la propriété à false, ce qui laisse Lit utiliser son défaut (true).
   // L'assignation impérative contourne ce comportement.
   const headerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (resolvedUserName) {
+      localStorage.setItem(CACHE_KEY, resolvedUserName);
+    }
+  }, [resolvedUserName]);
 
   useEffect(() => {
     if (headerRef.current) {

--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -20,7 +20,9 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   const { instance, accounts, inProgress } = useMsal();
   const isAuthenticated = useIsAuthenticated();
 
-  const account = instance.getActiveAccount() ?? accounts[0];
+  // getAllAccounts() lit le cache MSAL de façon synchrone — disponible dès le premier render
+  // après F5, contrairement à accounts[] (état React) qui se peuple en différé.
+  const account = instance.getActiveAccount() ?? instance.getAllAccounts()[0] ?? accounts[0];
   const emailClaim = account?.idTokenClaims?.['emails'];
   const emailFromToken =
     Array.isArray(emailClaim) && typeof emailClaim[0] === 'string' ? emailClaim[0] : undefined;


### PR DESCRIPTION
## Résumé

Après F5, le header affichait "Utilisateur" (valeur par défaut du DS) au lieu du nom/email de l'utilisateur connecté.

## Cause

`MsalProvider` démarre toujours avec `inProgress: 'startup'` et `accounts: []` quel que soit l'état du cache MSAL. Le temps que React state soit peuplé, `resolvedUserName` était vide (`''`), ce qui laissait Lit afficher son défaut `"Utilisateur"`.

## Fix

- `instance.getAllAccounts()[0]` ajouté comme fallback synchrone avant `accounts[0]`
- Cache `localStorage` (`stockhub_username`) : le nom résolu est persisté dès qu'il est disponible, et lu immédiatement au premier render comme dernier fallback avant `''`
- Effacement de la clé au logout pour éviter de montrer le mauvais nom sur un autre compte

## Composant modifié

- `src/components/layout/HeaderWrapper.tsx`

## Test plan

- [x] Se connecter → nom/email affiché correctement
- [x] F5 → nom/email affiché immédiatement (pas de flash "Utilisateur")
- [x] Se déconnecter → clé localStorage effacée
- [x] Se reconnecter avec un autre compte → bon nom affiché

Closes #172