### PR TITLE
feat(items): display mobile cards on StockDetailPage — closes #165

### DIFF
--- a/ETAT-DU-PROJET.md
+++ b/ETAT-DU-PROJET.md
@@ -1,13 +1,38 @@
 # StockHub V2 Frontend — État du projet
 
-**Date de rédaction** : 13 juin 2026
-**Dernière activité** : 13 juin 2026 (session de reprise active)
-**Branche active** : `fix/172-username-after-refresh` (PR #177 ouverte, en attente de merge)
-**Version publiée** : v1.12.1 (Release Please a mergé automatiquement)
+**Date de rédaction** : 15 juin 2026
+**Dernière activité** : 15 juin 2026 (session active)
+**Branche active** : `feat/165-items-mobile-cards` (PR ouverte)
+**Version publiée** : v1.13.0 (Release Please — mergé le 15 juin)
 
 ---
 
-## Session du 12–13 juin 2026 — Ce qui a été fait
+## Session du 15 juin 2026 — Ce qui a été fait
+
+### Tickets fermés
+
+| #    | Titre                                   | PR          |
+| ---- | --------------------------------------- | ----------- |
+| #177 | Username "utilisateur" après F5         | ✅ mergé    |
+| #165 | Items en cards sur mobile (StockDetail) | PR en cours |
+
+### Fix CI
+
+`deploy-metrics.yml` utilisait Node 18, incompatible avec Vite 6.3.5 (exige ≥ 20.19). Passé à Node 20, pushé directement sur `main`.
+
+### #165 — Items en cards sur mobile
+
+Nouveau composant `src/components/items/ItemMobileCard.tsx` :
+
+- Vue cards visible sur mobile (`md:hidden`), tableau conservé sur desktop (`hidden md:block`)
+- Chaque card affiche : nom + badge statut, quantité (role-based), min, date relative, actions directes
+- Gestion des rôles : OWNER (±/inline edit), VIEWER_CONTRIBUTOR (bouton Signaler), VIEWER (lecture seule)
+- Bug découvert et corrigé : `autoFocus` sur deux inputs simultanés (mobile + desktop) causait un conflit de focus → `onBlur` immédiat → `editingQuantityId = null`. Fix : `autoFocus` retiré de la card mobile.
+- Tests adaptés : `data-testid="qty-edit-span-{id}"` et `data-testid="qty-input-{id}"` pour cibler précisément le tableau desktop depuis les tests
+
+---
+
+## Sessions précédentes — 12–13 juin 2026
 
 ### Tickets fermés
 
@@ -17,10 +42,7 @@
 | #138 | Masquer cloche landing + corriger copyright year    | #174 ✅ |
 | #16  | Normalisation accents dans la recherche             | #175 ✅ |
 | #62  | Date relative sur les cartes stocks ("Il y a X j")  | #176 ✅ |
-
-### Bug corrigé en cours (#175)
-
-La recherche ne filtrait pas les cartes stocks — `ownedStocks` et `sharedStocks` étaient dérivés de `stocks` brut au lieu de `filteredStocks`. Corrigé dans `useStocks.ts`.
+| #172 | Username "utilisateur" après F5                     | #177 ✅ |
 
 ### Nouveau fichier utilitaire
 
@@ -28,12 +50,11 @@ La recherche ne filtrait pas les cartes stocks — `ownedStocks` et `sharedStock
 
 ### Tickets créés
 
-| #        | Repo  | Titre                                                           | Board       |
-| -------- | ----- | --------------------------------------------------------------- | ----------- |
-| #170     | Front | Rechercher un item par nom depuis le dashboard (bloqué backend) | Backlog     |
-| #172     | Front | Username "utilisateur" après F5                                 | In Progress |
-| DS#39    | DS    | Supprimer attributs `title` natifs sur boutons sh-header        | Backlog DS  |
-| Back#228 | Back  | Exposer `updatedAt` sur GET /api/v2/stocks                      | Backlog     |
+| #        | Repo  | Titre                                                           | Board      |
+| -------- | ----- | --------------------------------------------------------------- | ---------- |
+| #170     | Front | Rechercher un item par nom depuis le dashboard (bloqué backend) | Backlog    |
+| DS#39    | DS    | Supprimer attributs `title` natifs sur boutons sh-header        | Backlog DS |
+| Back#228 | Back  | Exposer `updatedAt` sur GET /api/v2/stocks                      | Backlog    |
 
 ### CI optimisé
 
@@ -43,9 +64,9 @@ Le workflow "Quality Audits" (Lighthouse, axe-core, bundle) saute les PRs Depend
 
 ## PR en attente de merge
 
-| PR   | Branche                          | Sujet                                  |
-| ---- | -------------------------------- | -------------------------------------- |
-| #177 | `fix/172-username-after-refresh` | Username après F5 (localStorage cache) |
+| PR  | Branche                       | Sujet                          |
+| --- | ----------------------------- | ------------------------------ |
+| PR  | `feat/165-items-mobile-cards` | Items en cards sur mobile #165 |
 
 ---
 
@@ -62,19 +83,24 @@ Le workflow "Quality Audits" (Lighthouse, axe-core, bundle) saute les PRs Depend
 
 ### Fonctionnalités livrées (résumé par release)
 
-**Session 12–13 juin 2026** _(à venir dans prochaine release)_
+**Session 15 juin 2026** _(à venir dans prochaine release)_
+
+- Items d'un stock affichés en cards sur mobile (tableau conservé sur desktop)
+- Actions (modifier, supprimer) visibles directement sur la card (pas de hover nécessaire)
+- Fix Node 18 → 20 dans le workflow deploy-metrics
+
+**v1.13.0 — 15 juin 2026**
 
 - Cloche notifications : compteur réel (critique + rupture + contributions) + tooltip par stock au survol
 - Cloche masquée sur la landing page (non connecté)
 - Copyright year dynamique dans le footer
-- Recherche stocks avec normalisation des accents
-- Recherche stocks filtre bien les cartes (fix ownedStocks/sharedStocks)
+- Recherche stocks avec normalisation des accents (fix filtrage ownedStocks/sharedStocks)
 - Date relative sur les cartes stocks ("Il y a 5 j", "Hier", "14:30")
 - Username après F5 : lu depuis localStorage en attendant MSAL
 
 **v1.12.1 — mai 2026**
 
-- Colonne "dernière mise à jour" dans le tableau des items (affiche l'heure si aujourd'hui)
+- Colonne "dernière mise à jour" dans le tableau des items
 - Compteur réel de contributions en attente sur la cloche du header
 - Layout responsive amélioré (mobile)
 - Bannière "lecture seule" et carte cliquable pour le rôle VIEWER
@@ -103,18 +129,17 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 ## Backlog — ce qui reste à faire
 
-### PR à merger en priorité
+### PR à merger
 
-| PR   | Sujet                       |
-| ---- | --------------------------- |
-| #177 | Username après F5 (fix/172) |
+| PR  | Sujet                        |
+| --- | ---------------------------- |
+| PR  | Items en cards mobile (#165) |
 
 ### Bugs ouverts
 
-| #    | Titre                                                    | Priorité           |
-| ---- | -------------------------------------------------------- | ------------------ |
-| #172 | Username "utilisateur" après F5                          | En cours (PR #177) |
-| #30  | Comportement `optionalDependencies` Vercel à investiguer | P1                 |
+| #   | Titre                                                    | Priorité |
+| --- | -------------------------------------------------------- | -------- |
+| #30 | Comportement `optionalDependencies` Vercel à investiguer | P1       |
 
 ### Design System — à faire dans stockhub_design_system
 
@@ -140,7 +165,6 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 | #    | Titre                                                         | Nature                   |
 | ---- | ------------------------------------------------------------- | ------------------------ |
-| #165 | Afficher les items d'un stock en cards sur mobile             | UX mobile                |
 | #163 | Panneau de notifications avec alertes contextuelles           | Feature (front + back)   |
 | #170 | Rechercher un item par nom depuis le dashboard                | Feature (bloqué backend) |
 | #145 | Shopping list UI — générer, afficher, exporter                | Feature IA               |
@@ -180,25 +204,19 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 ---
 
-## Pour demain — par où commencer
+## Pour la prochaine session — par où commencer
 
-### 1. Merger PR #177 (5 min)
+### 1. Merger PR #165 (5 min)
 
-Vérifier CI vert et merger `fix/172-username-after-refresh`.
+Vérifier CI vert et merger `feat/165-items-mobile-cards`.
 
-### 2. Design System DS#39 (30–60 min)
+### 2. Feature #163 — Panneau notifications (2–3h)
 
-Supprimer les attributs `title` natifs sur les boutons `sh-header` (cloche, thème, connexion) dans le repo `stockhub_design_system`. Republier le package et mettre à jour la dépendance dans le front.
+L'infrastructure est posée (cloche avec compteur + tooltip). Étape suivante : un panneau/drawer qui s'ouvre au clic sur la cloche, listant les stocks critiques/en rupture + contributions en attente.
 
-> C'est la correction propre du tooltip "Notifications" qu'on a contourné côté front dans `HeaderWrapper`.
+### 3. DS#39 (session dédiée DS)
 
-### 3. Feature #165 — Items en cards sur mobile (1–2h)
-
-Suite logique du responsive. Les items sont en tableau, pas adapté au petit écran.
-
-### 4. Feature #163 — Panneau notifications (2–3h)
-
-L'infrastructure est posée (cloche avec compteur + tooltip). L'étape suivante est un panneau/drawer qui s'ouvre au clic sur la cloche.
+Supprimer les `title` natifs sur les boutons `sh-header` dans `stockhub_design_system`. À grouper avec d'autres évolutions DS.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ StockHub V2 est une application web moderne de gestion de stocks développée av
 
 ---
 
+## 🎉 Nouveautés Majeures (Juin 2026)
+
+### 📱 Items en cards sur mobile (Juin 2026)
+
+- **`ItemMobileCard`** : composant dédié affichant chaque item en card empilée sur mobile (`< md`)
+- Le tableau existant est conservé intact sur desktop (`≥ md`) — switch purement CSS (`md:hidden` / `hidden md:block`)
+- Gestion complète des rôles : OWNER (±/inline edit), VIEWER_CONTRIBUTOR (bouton Signaler), VIEWER (lecture seule)
+- Actions Modifier/Supprimer visibles directement sur la card, sans hover requis (adapté tactile)
+
+### 🔔 Notifications & UX Header (Juin 2026)
+
+- **Cloche notifications** : compteur réel (stocks critiques + ruptures + contributions en attente) + tooltip par stock au survol
+- **Cloche masquée** sur la landing page (non connecté) via injection CSS dans le shadow DOM `sh-header`
+- **Copyright year dynamique** dans le footer
+- **Recherche accents** : normalisation NFD pour trouver "café" en tapant "cafe"
+- **Date relative** sur les cartes stocks (`formatRelativeDate`) : "Il y a 5 j", "Hier", "14:30"
+- **Username après F5** : cache localStorage `stockhub_username` comme fallback pendant l'init MSAL
+
+---
+
 ## 🎉 Nouveautés Majeures (Mars 2026)
 
 ### 🔮 Prédictions & Historique Backend (Mars 2026)

--- a/docs/adr/ADR-001-items-responsive-dual-view.md
+++ b/docs/adr/ADR-001-items-responsive-dual-view.md
@@ -1,0 +1,62 @@
+# ADR-001 — Dual-view responsive pour les items de stock (mobile cards + desktop table)
+
+**Date** : 15 juin 2026
+**Statut** : Accepté
+**Issue** : #165
+
+---
+
+## Contexte
+
+La page `StockDetailPage` affiche les items d'un stock dans un tableau HTML. Sur mobile, ce tableau est tronqué et illisible malgré `overflow-x-auto`. Les utilisateurs ne pouvaient ni lire les données ni interagir avec les boutons d'action (modifier, supprimer), invisibles sur hover sur écran tactile.
+
+## Décision
+
+Approche **dual-view CSS** : deux sections rendues simultanément dans le DOM, visibilité alternée par Tailwind :
+
+```tsx
+{/* Vue cards — mobile */}
+<div className="md:hidden space-y-3">
+  {paginatedItems.map(item => <ItemMobileCard ... />)}
+</div>
+
+{/* Vue tableau — desktop */}
+<div className="hidden md:block ...">
+  <table>...</table>
+</div>
+```
+
+Le composant `ItemMobileCard` (`src/components/items/ItemMobileCard.tsx`) est autonome et reçoit les mêmes props/callbacks que les lignes du tableau.
+
+## Alternatives écartées
+
+| Alternative                                    | Raison du rejet                                           |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| `overflow-x-scroll` seul                       | UX dégradée, navigation difficile                         |
+| Réorganisation du tableau en colonnes empilées | Cassait la sémantique table/thead/tbody                   |
+| Composant DS `<sh-stock-item-card>`            | Props insuffisants : pas de rôles, pas d'inline edit      |
+| État local dans ItemMobileCard                 | Désynchronisation avec la vue desktop (même ligne éditée) |
+
+## Contrainte découverte : conflit `autoFocus` entre vues
+
+Les deux vues partagent le state `editingQuantityId`. Quand l'utilisateur ouvre l'éditeur inline :
+
+1. Desktop : input avec `autoFocus` → focus sur l'input desktop
+2. Mobile : input avec `autoFocus` → focus sur l'input mobile → **blur sur l'input desktop**
+3. `onBlur` du desktop appelle `setEditingQuantityId(null)` → éditeur fermé immédiatement
+
+**Fix** : `autoFocus` retiré du composant `ItemMobileCard`. Le desktop conserve `autoFocus` (UX clavier). Sur mobile le tap sur la valeur ouvre l'input sans focus automatique — ce qui est acceptable sur tactile.
+
+## Impact sur les tests
+
+jsdom n'applique pas le CSS. En test, les deux vues sont visibles simultanément :
+
+- `getByText('Tomates')` → erreur "found multiple elements" → changé en `getAllByText`
+- `getByRole('spinbutton')` → deux inputs pour le même item → requêtes scopées via `data-testid="qty-edit-span-{id}"` et `data-testid="qty-input-{id}"` (ajoutés sur la vue desktop uniquement)
+
+## Conséquences
+
+- **Positif** : aucun changement de logique ou d'état, même pagination, mêmes callbacks
+- **Positif** : le tableau desktop est préservé exactement, pas de régression
+- **Négatif** : deux fois plus d'éléments dans le DOM (impact négligeable : 20 items max par page)
+- **À surveiller** : si un troisième point de rupture (ex. tablette) est ajouté, le pattern peut être étendu

--- a/src/components/items/ItemMobileCard.tsx
+++ b/src/components/items/ItemMobileCard.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
+import { formatRelativeDate } from '@/utils/dateUtils';
+import type { StockDetailItem } from '@/types';
+
+const STATUS_LABELS: Record<string, string> = {
+  optimal: 'OK',
+  low: 'Stock bas',
+  critical: 'Critique',
+  'out-of-stock': 'Rupture',
+};
+
+const STATUS_DOT_COLORS: Record<string, string> = {
+  optimal: 'bg-green-500',
+  low: 'bg-yellow-500',
+  critical: 'bg-orange-500',
+  'out-of-stock': 'bg-red-600',
+};
+
+const STATUS_BADGE_COLORS: Record<string, string> = {
+  optimal: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  low: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  critical: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  'out-of-stock': 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+};
+
+interface ItemMobileCardProps {
+  item: StockDetailItem;
+  status: 'optimal' | 'low' | 'critical' | 'out-of-stock';
+  myRole: string | undefined;
+  theme: 'light' | 'dark';
+  textMuted: string;
+  cardBg: string;
+  editingQuantityId: number | null;
+  setEditingQuantityId: (id: number | null) => void;
+  inlineQuantityValue: number;
+  setInlineQuantityValue: (v: number) => void;
+  onUpdateQuantity: (item: StockDetailItem, delta: number) => void;
+  onUpdateItem: (id: number, data: { quantity: number }) => Promise<unknown>;
+  onRefetch: () => void;
+  onEdit: (item: StockDetailItem) => void;
+  onDelete: (item: StockDetailItem) => void;
+  onContribute: (item: StockDetailItem) => void;
+  isLoadingUpdate: boolean;
+  isLoadingDelete: boolean;
+}
+
+export const ItemMobileCard: React.FC<ItemMobileCardProps> = ({
+  item,
+  status,
+  myRole,
+  theme,
+  textMuted,
+  cardBg,
+  editingQuantityId,
+  setEditingQuantityId,
+  inlineQuantityValue,
+  setInlineQuantityValue,
+  onUpdateQuantity,
+  onUpdateItem,
+  onRefetch,
+  onEdit,
+  onDelete,
+  onContribute,
+  isLoadingUpdate,
+  isLoadingDelete,
+}) => {
+  const isOwnerOrEditor = myRole === 'OWNER' || myRole === 'EDITOR';
+  const isContributor = myRole === 'VIEWER_CONTRIBUTOR';
+
+  return (
+    <article
+      className={`rounded-xl border p-4 ${cardBg} ${
+        theme === 'dark' ? 'border-slate-700' : 'border-gray-200'
+      }`}
+      aria-label={`Item : ${item.label}`}
+    >
+      {/* Header : nom + badge statut */}
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className={`w-2 h-2 rounded-full flex-shrink-0 mt-1 ${STATUS_DOT_COLORS[status]}`}
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <p className="font-semibold truncate">{item.label}</p>
+            {item.description && (
+              <p className={`text-xs truncate ${textMuted}`}>{item.description}</p>
+            )}
+          </div>
+        </div>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0 ${STATUS_BADGE_COLORS[status]}`}
+        >
+          {STATUS_LABELS[status]}
+        </span>
+      </div>
+
+      {/* Quantité */}
+      <div className="flex items-center justify-between mb-2">
+        <span className={`text-sm ${textMuted}`}>Quantité</span>
+        {myRole === 'VIEWER' ? (
+          <span className="font-bold tabular-nums">{item.quantity}</span>
+        ) : isContributor ? (
+          <div className="flex items-center gap-2">
+            <span className="font-bold tabular-nums">{item.quantity}</span>
+            <button
+              onClick={() => onContribute(item)}
+              className="text-xs px-2 py-1 rounded bg-amber-500/20 text-amber-400 border border-amber-500/30 hover:bg-amber-500/30 transition-colors"
+              aria-label={`Signaler une modification pour ${item.label}`}
+            >
+              Signaler
+            </button>
+          </div>
+        ) : isOwnerOrEditor ? (
+          <div className="flex items-center gap-1" aria-label={`Quantité : ${item.quantity}`}>
+            <button
+              onClick={() => onUpdateQuantity(item, -1)}
+              disabled={isLoadingUpdate}
+              className="w-7 h-7 flex items-center justify-center rounded hover:bg-purple-100 dark:hover:bg-slate-600 disabled:opacity-50 text-lg"
+              aria-label={`Diminuer la quantité de ${item.label}`}
+            >
+              −
+            </button>
+            {editingQuantityId === item.id ? (
+              <input
+                type="number"
+                min={0}
+                value={inlineQuantityValue}
+                onChange={e => setInlineQuantityValue(Number(e.target.value))}
+                onBlur={() => {
+                  if (!isNaN(inlineQuantityValue) && inlineQuantityValue >= 0) {
+                    void onUpdateItem(item.id, { quantity: inlineQuantityValue });
+                    void onRefetch();
+                  }
+                  setEditingQuantityId(null);
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') e.currentTarget.blur();
+                  if (e.key === 'Escape') setEditingQuantityId(null);
+                }}
+                className="w-16 text-center px-1 py-0.5 border border-purple-500 rounded bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none"
+                aria-label={`Quantité de ${item.label}`}
+              />
+            ) : (
+              <span
+                className="font-bold cursor-pointer hover:text-purple-400 transition-colors min-w-[28px] text-center tabular-nums"
+                title="Toucher pour éditer"
+                onClick={() => {
+                  setEditingQuantityId(item.id);
+                  setInlineQuantityValue(item.quantity);
+                }}
+              >
+                {item.quantity}
+              </span>
+            )}
+            <button
+              onClick={() => onUpdateQuantity(item, +1)}
+              disabled={isLoadingUpdate}
+              className="w-7 h-7 flex items-center justify-center rounded hover:bg-purple-100 dark:hover:bg-slate-600 disabled:opacity-50 text-lg"
+              aria-label={`Augmenter la quantité de ${item.label}`}
+            >
+              +
+            </button>
+          </div>
+        ) : (
+          <span className="font-bold tabular-nums">{item.quantity}</span>
+        )}
+      </div>
+
+      {/* Min + date */}
+      <div className={`flex items-center justify-between text-sm ${textMuted} mb-3`}>
+        <span>Min : {item.minimumStock ?? '—'}</span>
+        <span>{formatRelativeDate(item.updatedAt)}</span>
+      </div>
+
+      {/* Actions */}
+      {isOwnerOrEditor && (
+        <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-700/30">
+          <button
+            onClick={() => onEdit(item)}
+            className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-purple-600 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-slate-600 transition-colors"
+            aria-label={`Modifier ${item.label}`}
+          >
+            <Pencil className="w-3.5 h-3.5" />
+            Modifier
+          </button>
+          <button
+            onClick={() => onDelete(item)}
+            disabled={isLoadingDelete}
+            className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+            aria-label={`Supprimer ${item.label}`}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            Supprimer
+          </button>
+        </div>
+      )}
+    </article>
+  );
+};

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -11,6 +11,7 @@ import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
 import { MetricCardWrapper } from '@/components/dashboard/MetricCardWrapper';
 import { StockFormModal } from '@/components/stocks/StockFormModal';
 import { ItemFormModal } from '@/components/items/ItemFormModal';
+import { ItemMobileCard } from '@/components/items/ItemMobileCard';
 
 import { useStockDetail } from '@/hooks/useStockDetail';
 import { useItems } from '@/hooks/useItems';
@@ -467,7 +468,41 @@ export const StockDetailPage: React.FC = () => {
             </div>
           ) : (
             <>
-              <div className={`rounded-xl border overflow-hidden ${themeClasses.table}`}>
+              {/* Vue cards — mobile uniquement */}
+              <div className="md:hidden space-y-3">
+                {paginatedItems.map(item => {
+                  const status = getItemStatus(item);
+                  return (
+                    <ItemMobileCard
+                      key={item.id}
+                      item={item}
+                      status={status}
+                      myRole={myRole}
+                      theme={theme}
+                      textMuted={themeClasses.textMuted}
+                      cardBg={theme === 'dark' ? 'bg-slate-800' : 'bg-white'}
+                      editingQuantityId={editingQuantityId}
+                      setEditingQuantityId={setEditingQuantityId}
+                      inlineQuantityValue={inlineQuantityValue}
+                      setInlineQuantityValue={setInlineQuantityValue}
+                      onUpdateQuantity={handleUpdateQuantity}
+                      onUpdateItem={updateItem}
+                      onRefetch={refetch}
+                      onEdit={setEditingItem}
+                      onDelete={handleDeleteItem}
+                      onContribute={setContributingItem}
+                      isLoadingUpdate={itemsLoading.update}
+                      isLoadingDelete={itemsLoading.delete}
+                    />
+                  );
+                })}
+              </div>
+
+              {/* Vue tableau — desktop uniquement */}
+              <div
+                data-testid="items-desktop-table"
+                className={`hidden md:block rounded-xl border overflow-hidden ${themeClasses.table}`}
+              >
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm" aria-label="Liste des items">
                     <thead>
@@ -548,6 +583,7 @@ export const StockDetailPage: React.FC = () => {
                                       min={0}
                                       value={inlineQuantityValue}
                                       autoFocus
+                                      data-testid={`qty-input-${item.id}`}
                                       onChange={e => setInlineQuantityValue(Number(e.target.value))}
                                       onBlur={() => {
                                         if (
@@ -572,6 +608,7 @@ export const StockDetailPage: React.FC = () => {
                                     <span
                                       className="font-bold cursor-pointer hover:text-purple-400 transition-colors min-w-[24px] text-center tabular-nums"
                                       title="Cliquer pour éditer"
+                                      data-testid={`qty-edit-span-${item.id}`}
                                       onClick={() => {
                                         setEditingQuantityId(item.id);
                                         setInlineQuantityValue(item.quantity);
@@ -627,6 +664,7 @@ export const StockDetailPage: React.FC = () => {
                   </table>
                 </div>
               </div>
+              {/* fin vue tableau desktop */}
 
               {/* Pagination */}
               {totalPages > 1 && (

--- a/src/pages/__tests__/StockDetailPage.test.tsx
+++ b/src/pages/__tests__/StockDetailPage.test.tsx
@@ -191,8 +191,8 @@ describe('StockDetailPage', () => {
 
       const table = screen.getByRole('table', { name: /liste des items/i });
       expect(table).toBeInTheDocument();
-      expect(screen.getByText('Tomates')).toBeInTheDocument();
-      expect(screen.getByText('Carottes')).toBeInTheDocument();
+      expect(screen.getAllByText('Tomates').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Carottes').length).toBeGreaterThan(0);
     });
 
     it('should show empty state when stock has no items', async () => {
@@ -303,30 +303,28 @@ describe('StockDetailPage', () => {
     it('should show input when clicking on quantity value', async () => {
       await act(async () => renderPage());
 
-      const quantitySpans = screen.getAllByTitle('Cliquer pour éditer');
+      const editSpan = screen.getByTestId('qty-edit-span-1');
       await act(async () => {
-        fireEvent.click(quantitySpans[0]!);
+        fireEvent.click(editSpan);
       });
 
-      expect(screen.getByRole('spinbutton', { name: /quantité de tomates/i })).toBeInTheDocument();
+      expect(screen.getByTestId('qty-input-1')).toBeInTheDocument();
     });
 
     it('should hide input on Escape key', async () => {
       await act(async () => renderPage());
 
-      const quantitySpans = screen.getAllByTitle('Cliquer pour éditer');
+      const editSpan = screen.getByTestId('qty-edit-span-1');
       await act(async () => {
-        fireEvent.click(quantitySpans[0]!);
+        fireEvent.click(editSpan);
       });
 
-      const input = screen.getByRole('spinbutton', { name: /quantité de tomates/i });
+      const input = screen.getByTestId('qty-input-1');
       await act(async () => {
         fireEvent.keyDown(input, { key: 'Escape' });
       });
 
-      expect(
-        screen.queryByRole('spinbutton', { name: /quantité de tomates/i })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('qty-input-1')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Résumé

- Nouveau composant `ItemMobileCard` (`src/components/items/ItemMobileCard.tsx`) : carte empilée mobile, actions visibles directement (sans hover)
- Dual-view CSS dans `StockDetailPage` : `md:hidden` (cards) / `hidden md:block` (tableau) — les deux coexistent dans le DOM, même state partagé
- Gestion des rôles : OWNER (±/inline edit), VIEWER_CONTRIBUTOR (bouton Signaler), VIEWER (lecture seule)

## Composants modifiés

- `src/components/items/ItemMobileCard.tsx` ← nouveau
- `src/pages/StockDetailPage.tsx` ← ajout vue mobile + `data-testid` sur vue desktop
- `src/pages/__tests__/StockDetailPage.test.tsx` ← adaptation tests (dual render dans jsdom)
- `docs/adr/ADR-001-items-responsive-dual-view.md` ← nouveau (décision architecturale)
- `README.md`, `ETAT-DU-PROJET.md` ← mis à jour

## Fix notable : conflit `autoFocus`

Les deux vues partageant `editingQuantityId`, deux `<input autoFocus>` se rendaient simultanément → le second focus déclenchait le `onBlur` du premier → `setEditingQuantityId(null)` → éditeur fermé immédiatement.
Fix : `autoFocus` retiré de `ItemMobileCard`, conservé uniquement sur le tableau desktop.

## Plan de test

- [ ] Mobile (≤ 768px) : items affichés en cards avec nom, statut, quantité, actions directes
- [ ] Desktop (≥ 768px) : tableau inchangé
- [ ] Inline edit fonctionne sur desktop (clic sur quantité)
- [ ] Rôle VIEWER : lecture seule (pas de boutons d'action)
- [ ] Rôle VIEWER_CONTRIBUTOR : bouton "Signaler" visible
- [ ] Navigation clavier correcte (accessibilité)

Closes #165