### PR TITLE
feat(items): add item detail page — closes #181

### DIFF
--- a/ETAT-DU-PROJET.md
+++ b/ETAT-DU-PROJET.md
@@ -161,6 +161,7 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 | #    | Titre                                                         | Nature                   |
 | ---- | ------------------------------------------------------------- | ------------------------ |
+| #181 | Page détail d'un item de stock                                | Feature (P1 — en cours)  |
 | #163 | Panneau de notifications avec alertes contextuelles           | Feature (front + back)   |
 | #170 | Rechercher un item par nom depuis le dashboard                | Feature (bloqué backend) |
 | #145 | Shopping list UI — générer, afficher, exporter                | Feature IA               |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,9 @@ const Privacy = lazy(() =>
 const StockDetailPage = lazy(() =>
   import('@/pages/StockDetailPage.tsx').then(module => ({ default: module.StockDetailPage }))
 );
+const ItemDetailPage = lazy(() =>
+  import('@/pages/ItemDetailPage.tsx').then(module => ({ default: module.ItemDetailPage }))
+);
 
 // Composant de chargement accessible
 const LoadingFallback = () => (
@@ -95,6 +98,14 @@ function AppRoutes() {
             element={
               <ProtectedRoute>
                 <StockDetailPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/stocks/:stockId/items/:itemId"
+            element={
+              <ProtectedRoute>
+                <ItemDetailPage />
               </ProtectedRoute>
             }
           />

--- a/src/components/items/ItemMobileCard.tsx
+++ b/src/components/items/ItemMobileCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Pencil, Trash2 } from 'lucide-react';
 import { formatRelativeDate } from '@/utils/dateUtils';
 import type { StockDetailItem } from '@/types';
@@ -27,6 +28,7 @@ const STATUS_BADGE_COLORS: Record<string, string> = {
 interface ItemMobileCardProps {
   item: StockDetailItem;
   status: 'optimal' | 'low' | 'critical' | 'out-of-stock';
+  stockId: number | string;
   myRole: string | undefined;
   theme: 'light' | 'dark';
   textMuted: string;
@@ -48,6 +50,7 @@ interface ItemMobileCardProps {
 export const ItemMobileCard: React.FC<ItemMobileCardProps> = ({
   item,
   status,
+  stockId,
   myRole,
   theme,
   textMuted,
@@ -65,6 +68,7 @@ export const ItemMobileCard: React.FC<ItemMobileCardProps> = ({
   isLoadingUpdate,
   isLoadingDelete,
 }) => {
+  const navigate = useNavigate();
   const isOwnerOrEditor = myRole === 'OWNER' || myRole === 'EDITOR';
   const isContributor = myRole === 'VIEWER_CONTRIBUTOR';
 
@@ -83,7 +87,13 @@ export const ItemMobileCard: React.FC<ItemMobileCardProps> = ({
             aria-hidden="true"
           />
           <div className="min-w-0">
-            <p className="font-semibold truncate">{item.label}</p>
+            <button
+              onClick={() => navigate(`/stocks/${stockId}/items/${item.id}`)}
+              className="font-semibold truncate hover:text-purple-500 transition-colors text-left"
+              aria-label={`Voir le détail de ${item.label}`}
+            >
+              {item.label}
+            </button>
             {item.description && (
               <p className={`text-xs truncate ${textMuted}`}>{item.description}</p>
             )}

--- a/src/components/items/ItemMobileCard.tsx
+++ b/src/components/items/ItemMobileCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Pencil, Trash2 } from 'lucide-react';
+import { ChevronRight, Pencil, Trash2 } from 'lucide-react';
 import { formatRelativeDate } from '@/utils/dateUtils';
 import type { StockDetailItem } from '@/types';
 
@@ -185,27 +185,37 @@ export const ItemMobileCard: React.FC<ItemMobileCardProps> = ({
       </div>
 
       {/* Actions */}
-      {isOwnerOrEditor && (
-        <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-700/30">
-          <button
-            onClick={() => onEdit(item)}
-            className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-purple-600 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-slate-600 transition-colors"
-            aria-label={`Modifier ${item.label}`}
-          >
-            <Pencil className="w-3.5 h-3.5" />
-            Modifier
-          </button>
-          <button
-            onClick={() => onDelete(item)}
-            disabled={isLoadingDelete}
-            className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
-            aria-label={`Supprimer ${item.label}`}
-          >
-            <Trash2 className="w-3.5 h-3.5" />
-            Supprimer
-          </button>
-        </div>
-      )}
+      <div className="flex items-center justify-between pt-2 border-t border-slate-700/30">
+        <button
+          onClick={() => navigate(`/stocks/${stockId}/items/${item.id}`)}
+          className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-purple-600 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-slate-600 transition-colors"
+          aria-label={`Voir le détail de ${item.label}`}
+        >
+          <ChevronRight className="w-3.5 h-3.5" />
+          Voir
+        </button>
+        {isOwnerOrEditor && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => onEdit(item)}
+              className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-purple-600 dark:text-purple-400 hover:bg-purple-100 dark:hover:bg-slate-600 transition-colors"
+              aria-label={`Modifier ${item.label}`}
+            >
+              <Pencil className="w-3.5 h-3.5" />
+              Modifier
+            </button>
+            <button
+              onClick={() => onDelete(item)}
+              disabled={isLoadingDelete}
+              className="flex items-center gap-1 px-3 py-1.5 rounded text-sm text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+              aria-label={`Supprimer ${item.label}`}
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              Supprimer
+            </button>
+          </div>
+        )}
+      </div>
     </article>
   );
 };

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Home, Package } from 'lucide-react';
+
+import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
+import { FooterWrapper } from '@/components/layout/FooterWrapper';
+import { NavSection } from '@/components/layout/NavSection';
+import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
+import { useTheme } from '@/hooks/useTheme';
+import { ItemsAPI } from '@/services/api/itemsAPI';
+import type { RawItemDetail } from '@/services/api/itemsAPI';
+import { formatRelativeDate } from '@/utils/dateUtils';
+
+type ItemStatus = 'optimal' | 'low' | 'critical' | 'out-of-stock';
+
+const getStatus = (item: RawItemDetail): ItemStatus => {
+  const min = item.minimumStock ?? 1;
+  if (item.quantity === 0) return 'out-of-stock';
+  if (item.quantity < min) return 'critical';
+  if (item.quantity === min) return 'low';
+  return 'optimal';
+};
+
+const STATUS_LABELS: Record<ItemStatus, string> = {
+  optimal: 'OK',
+  low: 'Stock bas',
+  critical: 'Critique',
+  'out-of-stock': 'Rupture',
+};
+
+const STATUS_COLORS: Record<ItemStatus, string> = {
+  optimal: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  low: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  critical: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+  'out-of-stock': 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+};
+
+export const ItemDetailPage: React.FC = () => {
+  const { stockId, itemId } = useParams<{ stockId: string; itemId: string }>();
+  const navigate = useNavigate();
+  const { theme } = useTheme();
+
+  const [item, setItem] = useState<RawItemDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const themeClasses = {
+    background: theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50',
+    text: theme === 'dark' ? 'text-white' : 'text-gray-900',
+    textMuted: theme === 'dark' ? 'text-gray-300' : 'text-gray-600',
+    card: theme === 'dark' ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200',
+  };
+
+  useEffect(() => {
+    if (!stockId || !itemId) return;
+
+    setIsLoading(true);
+    ItemsAPI.fetchItem(stockId, itemId)
+      .then(data => {
+        setItem(data);
+        setError(null);
+      })
+      .catch(() => {
+        setError('Impossible de charger les informations de cet item.');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [stockId, itemId]);
+
+  const status = item ? getStatus(item) : null;
+
+  return (
+    <div className={`min-h-screen flex flex-col ${themeClasses.background} ${themeClasses.text}`}>
+      <HeaderWrapper />
+
+      <NavSection
+        breadcrumbs={[
+          { icon: Home, href: '/', label: 'Accueil' },
+          { href: `/stocks/${stockId}`, label: 'Stock' },
+          { label: item?.label ?? 'Item', current: true },
+        ]}
+      >
+        <Button
+          variant="ghost"
+          icon={ArrowLeft}
+          onClick={() => navigate(`/stocks/${stockId}`)}
+          aria-label="Retour à la liste des items"
+        >
+          <span className="hidden sm:inline">Retour</span>
+        </Button>
+      </NavSection>
+
+      <main id="main-content" className="flex-1 max-w-3xl mx-auto w-full px-4 py-6 space-y-6">
+        {isLoading && (
+          <div role="status" aria-live="polite" className="flex justify-center py-16">
+            <div
+              className="w-10 h-10 border-4 border-purple-500 border-t-transparent rounded-full animate-spin"
+              aria-hidden="true"
+            />
+            <span className="sr-only">Chargement de l'item…</span>
+          </div>
+        )}
+
+        {error && (
+          <div role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 text-red-700">
+            {error}
+          </div>
+        )}
+
+        {item && status && (
+          <>
+            {/* Header item */}
+            <div className="flex items-start gap-3">
+              <Package
+                className="w-7 h-7 text-purple-500 flex-shrink-0 mt-0.5"
+                aria-hidden="true"
+              />
+              <div className="min-w-0">
+                <h1 className={`text-2xl font-bold ${themeClasses.text}`}>{item.label}</h1>
+                {item.description && (
+                  <p className={`mt-1 text-sm ${themeClasses.textMuted}`}>{item.description}</p>
+                )}
+              </div>
+              <span
+                className={`ml-auto flex-shrink-0 px-3 py-1 rounded-full text-xs font-semibold ${STATUS_COLORS[status]}`}
+              >
+                {STATUS_LABELS[status]}
+              </span>
+            </div>
+
+            {/* Metrics */}
+            <div className={`grid grid-cols-2 gap-4 sm:grid-cols-3`}>
+              <div className={`rounded-xl border p-4 ${themeClasses.card}`}>
+                <p
+                  className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
+                >
+                  Quantité
+                </p>
+                <p className={`mt-1 text-3xl font-bold tabular-nums ${themeClasses.text}`}>
+                  {item.quantity}
+                </p>
+              </div>
+
+              <div className={`rounded-xl border p-4 ${themeClasses.card}`}>
+                <p
+                  className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
+                >
+                  Seuil minimum
+                </p>
+                <p className={`mt-1 text-3xl font-bold tabular-nums ${themeClasses.text}`}>
+                  {item.minimumStock}
+                </p>
+              </div>
+
+              {item.updatedAt && (
+                <div
+                  className={`rounded-xl border p-4 ${themeClasses.card} col-span-2 sm:col-span-1`}
+                >
+                  <p
+                    className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
+                  >
+                    Dernière mise à jour
+                  </p>
+                  <p className={`mt-1 text-sm font-medium ${themeClasses.text}`}>
+                    {formatRelativeDate(item.updatedAt)}
+                  </p>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </main>
+
+      <FooterWrapper />
+    </div>
+  );
+};

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -477,6 +477,7 @@ export const StockDetailPage: React.FC = () => {
                       key={item.id}
                       item={item}
                       status={status}
+                      stockId={numericId}
                       myRole={myRole}
                       theme={theme}
                       textMuted={themeClasses.textMuted}
@@ -534,7 +535,13 @@ export const StockDetailPage: React.FC = () => {
                                   aria-hidden="true"
                                 />
                                 <div className="min-w-0">
-                                  <p className="font-medium truncate">{item.label}</p>
+                                  <button
+                                    onClick={() => navigate(`/stocks/${stockId}/items/${item.id}`)}
+                                    className="font-medium truncate hover:text-purple-500 transition-colors text-left"
+                                    aria-label={`Voir le détail de ${item.label}`}
+                                  >
+                                    {item.label}
+                                  </button>
                                   {item.description && (
                                     <p className={`text-xs truncate ${themeClasses.textMuted}`}>
                                       {item.description}

--- a/src/services/api/itemsAPI.ts
+++ b/src/services/api/itemsAPI.ts
@@ -1,6 +1,11 @@
 import { getApiConfig } from './utils';
 import type { StockItem, CreateItemData, UpdateItemData } from '../../types/stock';
 
+// Type brut retourné par GET /stocks/:stockId/items/:itemId
+export interface RawItemDetail extends StockItem {
+  updatedAt?: string | null;
+}
+
 /**
  * Client API pour les Items d'un Stock
  * Gère les opérations CRUD via l'API Backend v2
@@ -67,6 +72,24 @@ export class ItemsAPI {
 
     const updatedItem: StockItem = await response.json();
     return updatedItem;
+  }
+
+  /**
+   * Récupère un item par son id
+   */
+  static async fetchItem(
+    stockId: number | string,
+    itemId: number | string
+  ): Promise<RawItemDetail> {
+    const { apiUrl, config } = await getApiConfig('GET', 2);
+    const response = await fetch(`${apiUrl}/stocks/${stockId}/items/${itemId}`, config);
+
+    if (!response.ok) {
+      throw new Error(`HTTP response with status ${response.status}`);
+    }
+
+    const item: RawItemDetail = await response.json();
+    return item;
   }
 
   /**


### PR DESCRIPTION
## Résumé

- Nouvelle page `ItemDetailPage` à la route `/stocks/:stockId/items/:itemId`
- Appel `GET /api/v2/stocks/:stockId/items/:itemId` (endpoint backend)
- Affiche : label, statut calculé côté client, quantité, seuil minimum, date relative (`updatedAt`)
- Navigation depuis la liste : clic sur le nom de l'item (desktop) ou sur le label de la card (mobile)

## Composants modifiés

- `src/pages/ItemDetailPage.tsx` ← nouveau
- `src/services/api/itemsAPI.ts` ← `fetchItem()` + type `RawItemDetail`
- `src/App.tsx` ← route `/stocks/:stockId/items/:itemId`
- `src/pages/StockDetailPage.tsx` ← label item cliquable dans le tableau desktop
- `src/components/items/ItemMobileCard.tsx` ← label item cliquable + prop `stockId`

## Plan de test

- [x] Clic sur un item (desktop ou mobile) → navigue vers `/stocks/:id/items/:itemId`
- [x] La page affiche quantité, seuil minimum et date de mise à jour
- [x] Bouton "Retour" ramène à `StockDetailPage`
- [x] Breadcrumb correct : Accueil → Stock → [nom item]
- [x] État de chargement visible pendant le fetch
- [x] Message d'erreur si l'item est introuvable

Closes #181