### PR TITLE
fix(header): global notification count and tooltip on all pages — closes #183

### DIFF
--- a/ETAT-DU-PROJET.md
+++ b/ETAT-DU-PROJET.md
@@ -14,6 +14,16 @@
 | #    | Titre                                   | PR      |
 | ---- | --------------------------------------- | ------- |
 | #165 | Items en cards sur mobile (StockDetail) | #179 ✅ |
+| #181 | Page détail d'un item de stock          | #182 ✅ |
+
+### #181 — Page détail d'un item (PR #182)
+
+Nouvelle page `ItemDetailPage` (`/stocks/:stockId/items/:itemId`) :
+
+- Appel `GET /api/v2/stocks/:stockId/items/:itemId`
+- Affiche : label, statut calculé, quantité, seuil minimum, date relative (`updatedAt`)
+- Navigation : clic sur le nom de l'item (desktop) ou bouton "Voir →" (mobile card)
+- Nouveau type `RawItemDetail` et méthode `ItemsAPI.fetchItem()` dans `itemsAPI.ts`
 
 ### #165 — Items en cards sur mobile (PR #179)
 
@@ -89,6 +99,7 @@ Le workflow "Quality Audits" (Lighthouse, axe-core, bundle) saute les PRs Depend
 **Sessions 15–16 juin 2026** _(à venir dans prochaine release)_
 
 - Items d'un stock affichés en cards sur mobile (tableau conservé sur desktop) — #165
+- Page détail d'un item `/stocks/:stockId/items/:itemId` — #181
 - Fix Node 18 → 20 dans le workflow deploy-metrics
 
 **v1.13.0 — 15 juin 2026**
@@ -157,11 +168,16 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 | #101 | Auth interactive Playwright pour tests E2E           |
 | #51  | Accessibilité : améliorer score (4 issues critiques) |
 
+### Bugs ouverts (suite)
+
+| #    | Titre                                                               | Priorité |
+| ---- | ------------------------------------------------------------------- | -------- |
+| #183 | Compteur notifications incorrect sur StockDetailPage/ItemDetailPage | P1       |
+
 ### Features planifiées (par priorité d'intérêt)
 
 | #    | Titre                                                         | Nature                   |
 | ---- | ------------------------------------------------------------- | ------------------------ |
-| #181 | Page détail d'un item de stock                                | Feature (P1 — en cours)  |
 | #163 | Panneau de notifications avec alertes contextuelles           | Feature (front + back)   |
 | #170 | Rechercher un item par nom depuis le dashboard                | Feature (bloqué backend) |
 | #145 | Shopping list UI — générer, afficher, exporter                | Feature IA               |
@@ -203,7 +219,11 @@ Design System @stockhub/design-system v1.3.1 (18 Web Components Lit)
 
 ## Pour la prochaine session — par où commencer
 
-### 1. Feature #163 — Panneau notifications (2–3h)
+### 1. Fix #183 — Compteur notifications global (30 min)
+
+Créer un hook `useNotificationCount` partagé (stocks critiques + ruptures + contributions) et l'utiliser dans Dashboard, StockDetailPage et ItemDetailPage.
+
+### 2. Feature #163 — Panneau notifications (2–3h)
 
 L'infrastructure est posée (cloche avec compteur + tooltip). Étape suivante : un panneau/drawer qui s'ouvre au clic sur la cloche, listant les stocks critiques/en rupture + contributions en attente.
 

--- a/src/hooks/useNotificationCount.ts
+++ b/src/hooks/useNotificationCount.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import { StocksAPI } from '@/services/api/stocksAPI';
+import ConfigManager from '@/services/api/ConfigManager';
+
+interface NotificationState {
+  count: number;
+  tooltip: string[];
+}
+
+/**
+ * Compte global des notifications : stocks critiques + ruptures + contributions en attente.
+ * À utiliser sur les pages qui n'ont pas déjà la liste complète des stocks chargée (StockDetailPage, ItemDetailPage).
+ * Le Dashboard calcule son propre count depuis useStocks() pour éviter un fetch redondant.
+ */
+export function useNotificationCount(): NotificationState & { refresh: () => void } {
+  const [state, setState] = useState<NotificationState>({ count: 0, tooltip: [] });
+
+  const load = useCallback(async () => {
+    try {
+      const [stocks, pendingData] = await Promise.all([
+        StocksAPI.fetchStocksList(),
+        (async () => {
+          const config = await ConfigManager.getFetchConfig();
+          const res = await globalThis.fetch(
+            `${ConfigManager.getApiServerUrl()}/contributions/pending-count`,
+            config
+          );
+          if (!res.ok) return { count: 0 };
+          const json: { count: number } = await res.json();
+          return json;
+        })(),
+      ]);
+
+      const criticalStocks = stocks.filter(s => s.status === 'critical');
+      const ruptures = stocks.filter(s => s.status === 'out-of-stock');
+      const pendingCount = pendingData.count;
+
+      const count = criticalStocks.length + ruptures.length + pendingCount;
+      const tooltip: string[] = [
+        ...criticalStocks.map(s => `🔴 ${s.label} — critique`),
+        ...ruptures.map(s => `⚫ ${s.label} — rupture`),
+        ...(pendingCount > 0
+          ? [`🔔 ${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`]
+          : []),
+      ];
+
+      setState({ count, tooltip });
+    } catch {
+      // non-critical, silently ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { ...state, refresh: load };
+}

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -40,7 +40,7 @@ export const ItemDetailPage: React.FC = () => {
   const { stockId, itemId } = useParams<{ stockId: string; itemId: string }>();
   const navigate = useNavigate();
   const { theme } = useTheme();
-  const { count: notifCount } = useNotificationCount();
+  const { count: notifCount, tooltip: notifTooltip } = useNotificationCount();
 
   const [item, setItem] = useState<RawItemDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -74,7 +74,7 @@ export const ItemDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen flex flex-col ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={notifCount} />
+      <HeaderWrapper notificationCount={notifCount} notificationTooltip={notifTooltip} />
 
       <NavSection
         breadcrumbs={[

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -7,6 +7,7 @@ import { FooterWrapper } from '@/components/layout/FooterWrapper';
 import { NavSection } from '@/components/layout/NavSection';
 import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
 import { useTheme } from '@/hooks/useTheme';
+import { useNotificationCount } from '@/hooks/useNotificationCount';
 import { ItemsAPI } from '@/services/api/itemsAPI';
 import type { RawItemDetail } from '@/services/api/itemsAPI';
 import { formatRelativeDate } from '@/utils/dateUtils';
@@ -39,6 +40,7 @@ export const ItemDetailPage: React.FC = () => {
   const { stockId, itemId } = useParams<{ stockId: string; itemId: string }>();
   const navigate = useNavigate();
   const { theme } = useTheme();
+  const { count: notifCount } = useNotificationCount();
 
   const [item, setItem] = useState<RawItemDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -72,7 +74,7 @@ export const ItemDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen flex flex-col ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper />
+      <HeaderWrapper notificationCount={notifCount} />
 
       <NavSection
         breadcrumbs={[

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -77,7 +77,11 @@ export const StockDetailPage: React.FC = () => {
   const { stockId } = useParams<{ stockId: string }>();
   const navigate = useNavigate();
   const { theme } = useTheme();
-  const { count: notifCount, refresh: refreshPendingCount } = useNotificationCount();
+  const {
+    count: notifCount,
+    tooltip: notifTooltip,
+    refresh: refreshPendingCount,
+  } = useNotificationCount();
 
   const numericId = Number(stockId);
   const { stock, isLoading, error, refetch } = useStockDetail(numericId);
@@ -255,7 +259,7 @@ export const StockDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={notifCount} />
+      <HeaderWrapper notificationCount={notifCount} notificationTooltip={notifTooltip} />
 
       <NavSection>
         <div className="flex flex-wrap items-start gap-3">

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -21,7 +21,7 @@ import { CollaboratorsModal } from '@/components/stocks/CollaboratorsModal';
 import { ContributionFormModal } from '@/components/items/ContributionFormModal';
 import { PendingContributionsSection } from '@/components/stocks/PendingContributionsSection';
 import { useContributions } from '@/hooks/useContributions';
-import { usePendingContributionsCount } from '@/hooks/usePendingContributionsCount';
+import { useNotificationCount } from '@/hooks/useNotificationCount';
 import { AIAlertBannerWrapper } from '@/components/ai/AIAlertBannerWrapper';
 import { computePredictions } from '@/utils/stockPredictions';
 import { PredictionsAPI } from '@/services/api/predictionsAPI';
@@ -77,7 +77,7 @@ export const StockDetailPage: React.FC = () => {
   const { stockId } = useParams<{ stockId: string }>();
   const navigate = useNavigate();
   const { theme } = useTheme();
-  const { count: pendingCount, refresh: refreshPendingCount } = usePendingContributionsCount();
+  const { count: notifCount, refresh: refreshPendingCount } = useNotificationCount();
 
   const numericId = Number(stockId);
   const { stock, isLoading, error, refetch } = useStockDetail(numericId);
@@ -255,7 +255,7 @@ export const StockDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={pendingCount} />
+      <HeaderWrapper notificationCount={notifCount} />
 
       <NavSection>
         <div className="flex flex-wrap items-start gap-3">


### PR DESCRIPTION
## Problème

- `StockDetailPage` passait seulement `pendingContributionsCount` → manquait stocks critiques et ruptures
- `ItemDetailPage` passait `0` par défaut → aucune notification
- Le tooltip (liste des alertes par stock) n'apparaissait que sur le dashboard

## Fix

Nouveau hook `useNotificationCount` (`src/hooks/useNotificationCount.ts`) :
- Appelle `StocksAPI.fetchStocksList()` + `GET /contributions/pending-count` en parallèle
- Retourne `count` + `tooltip` identiques à ceux du dashboard
- Utilisé sur `StockDetailPage` et `ItemDetailPage`

## Composants modifiés

- `src/hooks/useNotificationCount.ts` ← nouveau
- `src/pages/StockDetailPage.tsx` ← remplace `usePendingContributionsCount` par `useNotificationCount`
- `src/pages/ItemDetailPage.tsx` ← ajoute `notificationCount` + `notificationTooltip`

## Plan de test

- [ ] Dashboard : compteur et tooltip inchangés
- [ ] StockDetailPage : cloche affiche le même nombre et les mêmes lignes que le dashboard
- [ ] ItemDetailPage : idem

Closes #183