### PR TITLE
feat(notifications): add notification panel drawer on bell click — closes #163

### DIFF
--- a/src/components/layout/HeaderWrapper.tsx
+++ b/src/components/layout/HeaderWrapper.tsx
@@ -3,6 +3,7 @@ import { useMsal, useIsAuthenticated } from '@azure/msal-react';
 import { useTheme } from '@/hooks/useTheme';
 import { loginRequest } from '@/config/authConfig';
 import { logger } from '@/utils/logger';
+import { NotificationPanel } from '@/components/layout/NotificationPanel';
 import type { HeaderProps } from '@/types';
 
 /**
@@ -13,9 +14,11 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
   userName,
   notificationCount = 0,
   notificationTooltip,
+  notifications = [],
   isLoggedIn: isLoggedInProp,
 }) => {
   const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { instance, accounts, inProgress } = useMsal();
   const isAuthenticated = useIsAuthenticated();
@@ -45,7 +48,7 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
 
   const handleNotifications = () => {
     logger.debug('Notifications clicked');
-    // TODO: Ouvrir le panneau de notifications
+    setIsPanelOpen(true);
   };
 
   const handleThemeToggle = () => {
@@ -140,13 +143,10 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
     bellButton?.addEventListener('mouseenter', onShow);
     bellButton?.addEventListener('mouseleave', onHide);
 
-    // Sur mobile (pas de hover), toggle au tap via l'événement custom du DS
+    // Clic sur la cloche : ouvre le panneau de notifications
     const onBellClick = () => {
-      setTooltipPos(prev => {
-        if (prev) return null;
-        const rect = bellButton?.getBoundingClientRect();
-        return rect ? { top: rect.bottom + 6, left: rect.left + rect.width / 2 } : null;
-      });
+      setTooltipPos(null);
+      setIsPanelOpen(true);
     };
 
     // Fermer le tooltip si on clique ailleurs
@@ -183,7 +183,7 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
         'onsh-login-click': handleLogin,
         'onsh-logout-click': handleLogout,
       })}
-      {notificationTooltip && notificationTooltip.length > 0 && tooltipPos && (
+      {notificationTooltip && notificationTooltip.length > 0 && tooltipPos && !isPanelOpen && (
         <div
           role="tooltip"
           style={{
@@ -202,6 +202,9 @@ export const HeaderWrapper: React.FC<HeaderProps> = ({
             <div key={i}>{line}</div>
           ))}
         </div>
+      )}
+      {isPanelOpen && (
+        <NotificationPanel notifications={notifications} onClose={() => setIsPanelOpen(false)} />
       )}
     </div>
   );

--- a/src/components/layout/NotificationPanel.tsx
+++ b/src/components/layout/NotificationPanel.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useRef } from 'react';
+import { X, AlertTriangle, Package, Bell } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '@/hooks/useTheme';
+import type { NotificationItem } from '@/types';
+
+interface NotificationPanelProps {
+  notifications: NotificationItem[];
+  onClose: () => void;
+}
+
+export const NotificationPanel: React.FC<NotificationPanelProps> = ({ notifications, onClose }) => {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  const critical = notifications.filter(n => n.type === 'critical');
+  const ruptures = notifications.filter(n => n.type === 'out-of-stock');
+  const contributions = notifications.filter(n => n.type === 'contribution');
+
+  const handleStockClick = (stockId: number) => {
+    navigate(`/stocks/${stockId}`);
+    onClose();
+  };
+
+  const isDark = theme === 'dark';
+  const panelBg = isDark ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200';
+  const textPrimary = isDark ? 'text-white' : 'text-gray-900';
+  const textMuted = isDark ? 'text-gray-400' : 'text-gray-500';
+  const borderColor = isDark ? 'border-slate-700' : 'border-gray-200';
+  const itemHover = isDark ? 'hover:bg-slate-700' : 'hover:bg-gray-100';
+  const contribBg = isDark ? 'bg-slate-700/50' : 'bg-gray-50';
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Panneau de notifications"
+        tabIndex={-1}
+        className={`fixed top-0 right-0 h-full w-full max-w-sm z-50 shadow-2xl border-l flex flex-col outline-none ${panelBg}`}
+      >
+        <div className={`flex items-center justify-between px-4 py-3 border-b ${borderColor}`}>
+          <div className="flex items-center gap-2">
+            <Bell className="w-5 h-5 text-purple-500" aria-hidden="true" />
+            <h2 className={`text-base font-semibold ${textPrimary}`}>Notifications</h2>
+            {notifications.length > 0 && (
+              <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-purple-600 text-white">
+                {notifications.length}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Fermer le panneau de notifications"
+            className={`p-1.5 rounded-lg transition-colors ${itemHover} ${textMuted}`}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto py-3 space-y-4 px-3">
+          {notifications.length === 0 && (
+            <div className={`text-center py-12 ${textMuted}`}>
+              <Bell className="w-10 h-10 mx-auto mb-3 opacity-30" aria-hidden="true" />
+              <p className="text-sm">Aucune notification</p>
+            </div>
+          )}
+
+          {critical.length > 0 && (
+            <section aria-label="Stocks critiques">
+              <h3
+                className={`text-xs font-semibold uppercase tracking-wide mb-2 px-1 ${textMuted}`}
+              >
+                Stocks critiques
+              </h3>
+              <ul className="space-y-1">
+                {critical.map(n => (
+                  <li key={`critical-${n.stockId}`}>
+                    <button
+                      onClick={() => n.stockId !== undefined && handleStockClick(n.stockId)}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left ${itemHover}`}
+                    >
+                      <AlertTriangle
+                        className="w-4 h-4 text-orange-500 flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className={`text-sm flex-1 ${textPrimary}`}>{n.label}</span>
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400 flex-shrink-0">
+                        Critique
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {ruptures.length > 0 && (
+            <section aria-label="Ruptures de stock">
+              <h3
+                className={`text-xs font-semibold uppercase tracking-wide mb-2 px-1 ${textMuted}`}
+              >
+                Ruptures de stock
+              </h3>
+              <ul className="space-y-1">
+                {ruptures.map(n => (
+                  <li key={`rupture-${n.stockId}`}>
+                    <button
+                      onClick={() => n.stockId !== undefined && handleStockClick(n.stockId)}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left ${itemHover}`}
+                    >
+                      <Package className="w-4 h-4 text-red-600 flex-shrink-0" aria-hidden="true" />
+                      <span className={`text-sm flex-1 ${textPrimary}`}>{n.label}</span>
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 flex-shrink-0">
+                        Rupture
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {contributions.length > 0 && (
+            <section aria-label="Contributions en attente">
+              <h3
+                className={`text-xs font-semibold uppercase tracking-wide mb-2 px-1 ${textMuted}`}
+              >
+                Contributions en attente
+              </h3>
+              <ul className="space-y-1">
+                {contributions.map((n, i) => (
+                  <li key={`contribution-${i}`}>
+                    <div className={`flex items-center gap-3 px-3 py-2.5 rounded-lg ${contribBg}`}>
+                      <Bell className="w-4 h-4 text-purple-500 flex-shrink-0" aria-hidden="true" />
+                      <span className={`text-sm ${textPrimary}`}>{n.label}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/hooks/useNotificationCount.ts
+++ b/src/hooks/useNotificationCount.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { StocksAPI } from '@/services/api/stocksAPI';
 import ConfigManager from '@/services/api/ConfigManager';
+import type { NotificationItem } from '@/types';
 
 interface NotificationState {
   count: number;
   tooltip: string[];
+  notifications: NotificationItem[];
 }
 
 /**
@@ -13,7 +15,11 @@ interface NotificationState {
  * Le Dashboard calcule son propre count depuis useStocks() pour éviter un fetch redondant.
  */
 export function useNotificationCount(): NotificationState & { refresh: () => void } {
-  const [state, setState] = useState<NotificationState>({ count: 0, tooltip: [] });
+  const [state, setState] = useState<NotificationState>({
+    count: 0,
+    tooltip: [],
+    notifications: [],
+  });
 
   const load = useCallback(async () => {
     try {
@@ -36,6 +42,7 @@ export function useNotificationCount(): NotificationState & { refresh: () => voi
       const pendingCount = pendingData.count;
 
       const count = criticalStocks.length + ruptures.length + pendingCount;
+
       const tooltip: string[] = [
         ...criticalStocks.map(s => `🔴 ${s.label} — critique`),
         ...ruptures.map(s => `⚫ ${s.label} — rupture`),
@@ -44,7 +51,28 @@ export function useNotificationCount(): NotificationState & { refresh: () => voi
           : []),
       ];
 
-      setState({ count, tooltip });
+      const notifications: NotificationItem[] = [
+        ...criticalStocks.map(s => ({
+          type: 'critical' as const,
+          stockId: typeof s.id === 'number' ? s.id : Number(s.id),
+          label: s.label,
+        })),
+        ...ruptures.map(s => ({
+          type: 'out-of-stock' as const,
+          stockId: typeof s.id === 'number' ? s.id : Number(s.id),
+          label: s.label,
+        })),
+        ...(pendingCount > 0
+          ? [
+              {
+                type: 'contribution' as const,
+                label: `${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`,
+              },
+            ]
+          : []),
+      ];
+
+      setState({ count, tooltip, notifications });
     } catch {
       // non-critical, silently ignore
     }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BarChart3, ChevronDown, ChevronRight, Download, Plus, Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import type { Stock } from '@/types';
+import type { Stock, NotificationItem } from '@/types';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
@@ -68,6 +68,34 @@ export const Dashboard: React.FC = () => {
       ...stocks.filter(s => s.status === 'out-of-stock').map(s => `⚫ ${s.label} — rupture`),
       ...(pendingCount > 0
         ? [`🔔 ${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`]
+        : []),
+    ],
+    [stocks, pendingCount]
+  );
+
+  const notificationItems = useMemo<NotificationItem[]>(
+    () => [
+      ...stocks
+        .filter(s => s.status === 'critical')
+        .map(s => ({
+          type: 'critical' as const,
+          stockId: typeof s.id === 'number' ? s.id : Number(s.id),
+          label: s.label,
+        })),
+      ...stocks
+        .filter(s => s.status === 'out-of-stock')
+        .map(s => ({
+          type: 'out-of-stock' as const,
+          stockId: typeof s.id === 'number' ? s.id : Number(s.id),
+          label: s.label,
+        })),
+      ...(pendingCount > 0
+        ? [
+            {
+              type: 'contribution' as const,
+              label: `${pendingCount} contribution${pendingCount > 1 ? 's' : ''} en attente`,
+            },
+          ]
         : []),
     ],
     [stocks, pendingCount]
@@ -206,6 +234,7 @@ export const Dashboard: React.FC = () => {
       <HeaderWrapper
         notificationCount={notificationCount}
         notificationTooltip={notificationTooltip}
+        notifications={notificationItems}
       />
 
       {/* Navigation Section */}

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -40,7 +40,11 @@ export const ItemDetailPage: React.FC = () => {
   const { stockId, itemId } = useParams<{ stockId: string; itemId: string }>();
   const navigate = useNavigate();
   const { theme } = useTheme();
-  const { count: notifCount, tooltip: notifTooltip } = useNotificationCount();
+  const {
+    count: notifCount,
+    tooltip: notifTooltip,
+    notifications: notifItems,
+  } = useNotificationCount();
 
   const [item, setItem] = useState<RawItemDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -74,7 +78,11 @@ export const ItemDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen flex flex-col ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={notifCount} notificationTooltip={notifTooltip} />
+      <HeaderWrapper
+        notificationCount={notifCount}
+        notificationTooltip={notifTooltip}
+        notifications={notifItems}
+      />
 
       <NavSection
         breadcrumbs={[

--- a/src/pages/StockDetailPage.tsx
+++ b/src/pages/StockDetailPage.tsx
@@ -80,6 +80,7 @@ export const StockDetailPage: React.FC = () => {
   const {
     count: notifCount,
     tooltip: notifTooltip,
+    notifications: notifItems,
     refresh: refreshPendingCount,
   } = useNotificationCount();
 
@@ -259,7 +260,11 @@ export const StockDetailPage: React.FC = () => {
 
   return (
     <div className={`min-h-screen ${themeClasses.background} ${themeClasses.text}`}>
-      <HeaderWrapper notificationCount={notifCount} notificationTooltip={notifTooltip} />
+      <HeaderWrapper
+        notificationCount={notifCount}
+        notificationTooltip={notifTooltip}
+        notifications={notifItems}
+      />
 
       <NavSection>
         <div className="flex flex-wrap items-start gap-3">

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -52,11 +52,18 @@ export interface NavSectionProps {
   className?: string;
 }
 
+export interface NotificationItem {
+  type: 'critical' | 'out-of-stock' | 'contribution';
+  stockId?: number;
+  label: string;
+}
+
 export interface HeaderProps {
   className?: string;
   userName?: string;
   notificationCount?: number;
   notificationTooltip?: string[];
+  notifications?: NotificationItem[];
   isLoggedIn?: boolean;
 }
 


### PR DESCRIPTION
## Composants modifiés

- `src/types/dashboard.ts` — nouveau type `NotificationItem` (`type`, `stockId?`, `label`) ; `HeaderProps` + prop `notifications?`
- `src/hooks/useNotificationCount.ts` — retourne désormais `notifications: NotificationItem[]` en plus de `count` et `tooltip`
- `src/components/layout/NotificationPanel.tsx` — nouveau drawer (fixed right) avec overlay, fermeture Escape/clic extérieur, sections Critiques / Ruptures / Contributions, navigation vers `/stocks/:stockId`
- `src/components/layout/HeaderWrapper.tsx` — état `isPanelOpen`, clic cloche → panel (tooltip hover conservé en desktop), import et rendu de `NotificationPanel`
- `src/pages/Dashboard.tsx` — calcul de `notificationItems: NotificationItem[]` depuis stocks déjà chargés, passé à `HeaderWrapper`
- `src/pages/StockDetailPage.tsx` — destructure `notifications` depuis `useNotificationCount`, passé à `HeaderWrapper`
- `src/pages/ItemDetailPage.tsx` — idem

## Test plan

- [x] Clic sur la cloche → panel s'ouvre depuis la droite
- [x] Overlay visible derrière le panel
- [x] Clic sur l'overlay → panel se ferme
- [x] Touche Escape → panel se ferme
- [x] Clic sur un stock dans le panel → navigation vers `/stocks/:id`
- [x] Panel disponible sur Dashboard, StockDetailPage, ItemDetailPage

Closes #163