### PR TITLE
feat(stocks): add confirm modal before delete and hide delete btn on shared stocks — closes #61

### DIFF
--- a/src/components/common/ConfirmDeleteModal.tsx
+++ b/src/components/common/ConfirmDeleteModal.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface ConfirmDeleteModalProps {
+  stockLabel: string;
+  isDeleting?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
+  stockLabel,
+  isDeleting = false,
+  onConfirm,
+  onClose,
+}) => {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-delete-title"
+        className="bg-white dark:bg-slate-800 rounded-xl shadow-2xl w-full max-w-sm mx-4 p-6"
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+            <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400" aria-hidden="true" />
+          </div>
+          <h2
+            id="confirm-delete-title"
+            className="text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            Supprimer ce stock ?
+          </h2>
+        </div>
+
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-6">
+          Le stock <strong className="text-gray-900 dark:text-white">« {stockLabel} »</strong> et
+          tous ses items seront définitivement supprimés. Cette action est irréversible.
+        </p>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            ref={cancelRef}
+            onClick={onClose}
+            disabled={isDeleting}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors disabled:opacity-50"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-red-600 hover:bg-red-700 text-white transition-colors disabled:opacity-50"
+          >
+            {isDeleting ? 'Suppression…' : 'Supprimer'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/__tests__/ConfirmDeleteModal.test.tsx
+++ b/src/components/common/__tests__/ConfirmDeleteModal.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
+
+const mockOnConfirm = vi.fn();
+const mockOnClose = vi.fn();
+
+const renderModal = (props?: Partial<Parameters<typeof ConfirmDeleteModal>[0]>) =>
+  render(
+    <ConfirmDeleteModal
+      stockLabel="Café Arabica"
+      onConfirm={mockOnConfirm}
+      onClose={mockOnClose}
+      {...props}
+    />
+  );
+
+describe('ConfirmDeleteModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should display the stock label in the confirmation message', () => {
+      renderModal();
+      expect(screen.getByText(/Café Arabica/)).toBeInTheDocument();
+    });
+
+    it('should display Annuler and Supprimer buttons', () => {
+      renderModal();
+      expect(screen.getByRole('button', { name: 'Annuler' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Supprimer' })).toBeInTheDocument();
+    });
+
+    it('should have role=dialog and aria-modal', () => {
+      renderModal();
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+  });
+
+  describe('actions', () => {
+    it('should call onConfirm when Supprimer is clicked', () => {
+      renderModal();
+      fireEvent.click(screen.getByRole('button', { name: 'Supprimer' }));
+      expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('should call onClose when Annuler is clicked', () => {
+      renderModal();
+      fireEvent.click(screen.getByRole('button', { name: 'Annuler' }));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('should call onClose when clicking the overlay', () => {
+      const { container } = renderModal();
+      const overlay = container.firstChild as HTMLElement;
+      fireEvent.click(overlay);
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose on Escape key', () => {
+      renderModal();
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when isDeleting is true', () => {
+    it('should show "Suppression…" text on the confirm button', () => {
+      renderModal({ isDeleting: true });
+      expect(screen.getByRole('button', { name: 'Suppression…' })).toBeInTheDocument();
+    });
+
+    it('should disable both buttons', () => {
+      renderModal({ isDeleting: true });
+      expect(screen.getByRole('button', { name: 'Annuler' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Suppression…' })).toBeDisabled();
+    });
+  });
+});

--- a/src/components/dashboard/StockCardWrapper.tsx
+++ b/src/components/dashboard/StockCardWrapper.tsx
@@ -55,6 +55,26 @@ export const StockCardWrapper: React.FC<StockCardProps> = ({
     });
   }, [aiSuggestions]);
 
+  // Masquer le bouton supprimer dans le shadow root quand onDelete n'est pas fourni
+  useEffect(() => {
+    customElements.whenDefined('sh-stock-card').then(() => {
+      const shadowRoot = cardRef.current?.shadowRoot;
+      if (!shadowRoot) return;
+      const styleId = 'hide-delete-btn';
+      const existing = shadowRoot.querySelector(`#${styleId}`);
+      if (!onDelete) {
+        if (!existing) {
+          const style = document.createElement('style');
+          style.id = styleId;
+          style.textContent = 'sh-button[icon-before="Trash2"] { display: none !important; }';
+          shadowRoot.appendChild(style);
+        }
+      } else {
+        existing?.remove();
+      }
+    });
+  }, [onDelete]);
+
   // Handler pour le bouton "Enregistrer session"
   const handleSessionClick = () => {
     if (localStock.unit !== 'percentage') return;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
 import { SearchInputWrapper } from '@/components/common/SearchInputWrapper';
 import { CardWrapper } from '@/components/common/CardWrapper';
 import { StockFormModal } from '@/components/stocks/StockFormModal';
+import { ConfirmDeleteModal } from '@/components/common/ConfirmDeleteModal';
 
 import { useStocks } from '@/hooks/useStocks';
 import { useDataExport } from '@/hooks/useFrontendState';
@@ -28,6 +29,7 @@ export const Dashboard: React.FC = () => {
   const [editingStock, setEditingStock] = useState<Stock | null>(null);
   const [isOwnedExpanded, setIsOwnedExpanded] = useState<boolean>(true);
   const [isSharedExpanded, setIsSharedExpanded] = useState<boolean>(true);
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | string | null>(null);
 
   const navigate = useNavigate();
   const { theme } = useTheme();
@@ -158,12 +160,15 @@ export const Dashboard: React.FC = () => {
     setIsFormOpen(true);
   }, []);
 
-  const handleDeleteStock = useCallback(
-    async (stockId: number | string): Promise<void> => {
-      await deleteStock(stockId);
-    },
-    [deleteStock]
-  );
+  const handleDeleteStock = useCallback((stockId: number | string) => {
+    setPendingDeleteId(stockId);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (pendingDeleteId === null) return;
+    await deleteStock(pendingDeleteId);
+    setPendingDeleteId(null);
+  }, [deleteStock, pendingDeleteId]);
 
   const handleUpdateStock = useCallback(
     (stockId: number | string) => {
@@ -549,6 +554,15 @@ export const Dashboard: React.FC = () => {
             setIsFormOpen(false);
             setEditingStock(null);
           }}
+        />
+      )}
+
+      {pendingDeleteId !== null && (
+        <ConfirmDeleteModal
+          stockLabel={getStockById(pendingDeleteId)?.label ?? 'ce stock'}
+          isDeleting={isLoading.delete}
+          onConfirm={() => void handleConfirmDelete()}
+          onClose={() => setPendingDeleteId(null)}
         />
       )}
     </div>


### PR DESCRIPTION
## Composants modifiés

- `src/components/common/ConfirmDeleteModal.tsx` — nouvelle modale de confirmation (overlay, Escape, autofocus Annuler, nom du stock dans le message, état isDeleting)
- `src/pages/Dashboard.tsx` — état `pendingDeleteId`, `handleDeleteStock` intercepte pour ouvrir la modale, `handleConfirmDelete` appelle réellement `deleteStock`
- `src/components/dashboard/StockCardWrapper.tsx` — injection CSS shadow root pour masquer le bouton Supprimer quand `onDelete` n'est pas fourni (stocks partagés)

## Tests

- `src/components/common/__tests__/ConfirmDeleteModal.test.tsx` — 9 tests : rendu, actions (confirm/cancel/overlay/Escape), état isDeleting

## Test plan

- [x] Clic Supprimer sur un stock → modale avec nom du stock
- [x] Clic Annuler → modale fermée, pas de suppression
- [x] Clic Supprimer dans la modale → suppression effective
- [x] Escape → modale fermée
- [x] Stocks partagés → bouton Supprimer absent

Closes #61