### PR TITLE
fix(auth): add reconnect button + clear stale interaction lock — closes #189

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BarChart3, ChevronDown, ChevronRight, Download, Plus, Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { Stock, NotificationItem } from '@/types';
+import { msalInstance } from '@/config/msalInstance';
+import { loginRequest } from '@/config/authConfig';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
@@ -215,7 +217,7 @@ export const Dashboard: React.FC = () => {
               <p className="text-sm text-red-400">Suppression: {errors.delete.message}</p>
             )}
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 flex-wrap">
             <Button onClick={() => window.location.reload()}>Recharger</Button>
             <Button
               variant="secondary"
@@ -227,6 +229,12 @@ export const Dashboard: React.FC = () => {
               }}
             >
               Réessayer
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => void msalInstance.loginRedirect(loginRequest)}
+            >
+              Se reconnecter
             </Button>
           </div>
         </CardWrapper>

--- a/src/services/api/ConfigManager.ts
+++ b/src/services/api/ConfigManager.ts
@@ -13,6 +13,11 @@ const getToken = async (): Promise<string | null> => {
   const account = msalInstance.getActiveAccount();
   if (!account) return null;
 
+  // Supprime les verrous d'interaction périmés qui bloquent l'acquisition silencieuse
+  Object.keys(sessionStorage)
+    .filter(k => k.includes('interaction.status'))
+    .forEach(k => sessionStorage.removeItem(k));
+
   try {
     const response = await msalInstance.acquireTokenSilent({
       ...loginRequest,
@@ -20,8 +25,9 @@ const getToken = async (): Promise<string | null> => {
     });
     return response.accessToken;
   } catch (error) {
+    console.error('[getToken] token acquisition failed:', error);
     if (error instanceof InteractionRequiredAuthError) {
-      await msalInstance.acquireTokenRedirect({ ...loginRequest, account });
+      void msalInstance.loginRedirect(loginRequest);
     }
     return null;
   }


### PR DESCRIPTION
## Summary

- Bouton **Se reconnecter** dans l'écran d'erreur du Dashboard — relance un `loginRedirect` sans recharger manuellement
- `ConfigManager.getToken()` : suppression des verrous `interaction.status` périmés avant `acquireTokenSilent`
- `ConfigManager.getToken()` : log des échecs d'acquisition de token pour faciliter le diagnostic
- `InteractionRequiredAuthError` : utilise `loginRedirect` au lieu de `acquireTokenRedirect` (plus fiable)

## Composants modifiés

- `src/services/api/ConfigManager.ts`
- `src/pages/Dashboard.tsx`

## Test plan

- [x] Laisser le token expirer (~1h d'inactivité)
- [x] Vérifier que l'écran d'erreur affiche le bouton "Se reconnecter"
- [x] Cliquer "Se reconnecter" → doit rediriger vers Azure B2C → Dashboard fonctionnel

Closes #189