### PR TITLE
feat: upgrader @stockhub/design-system vers v2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@azure/msal-browser": "^4.27.0",
         "@azure/msal-react": "^3.0.23",
-        "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.3",
+        "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v2.0.3",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.517.0",
         "react": "19.2.3",
@@ -966,16 +966,18 @@
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.4.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2290,17 +2292,17 @@
       "license": "MIT"
     },
     "node_modules/@stockhub/design-system": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/SandrineCipolla/stockhub_design_system.git#eb0f7a26f9cb0480092cb3fcd57bf6f1a69f8976",
+      "version": "2.0.3",
+      "resolved": "git+ssh://git@github.com/SandrineCipolla/stockhub_design_system.git#0413e732b4d8d6a028a7b2c459499ee9332ac782",
       "license": "ISC",
       "dependencies": {
         "color-contrast-checker": "^2.1.0",
-        "lit": "^2.8.0",
-        "lucide": "^0.546.0",
+        "lit": "^3.3.3",
+        "lucide": "^1.25.0",
         "wcag-contrast": "^3.0.0"
       },
       "peerDependencies": {
-        "lit": "^2.8.0"
+        "lit": "^3.3.3"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2506,6 +2508,8 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -5539,31 +5543,31 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -5667,7 +5671,9 @@
       "license": "MIT"
     },
     "node_modules/lucide": {
-      "version": "0.546.0",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.25.0.tgz",
+      "integrity": "sha512-Pg/9Ga1xTbrnI6GY/7J9krIYmJIkAf3PkK6wPmsAeUtAQsBdGxs1+dfvLqjf9nPI5aFm9+VquT75JGpO3QXSpQ==",
       "license": "ISC"
     },
     "node_modules/lucide-react": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@azure/msal-browser": "^4.27.0",
     "@azure/msal-react": "^3.0.23",
-    "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v1.3.3",
+    "@stockhub/design-system": "github:SandrineCipolla/stockhub_design_system#v2.0.3",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.517.0",
     "react": "19.2.3",

--- a/src/components/items/ContributionFormModal.tsx
+++ b/src/components/items/ContributionFormModal.tsx
@@ -42,11 +42,11 @@ export const ContributionFormModal: React.FC<Props> = ({
 
     const handleCancel = () => onClose();
 
-    el.addEventListener('contribution-submit', handleSubmit);
-    el.addEventListener('contribution-cancel', handleCancel);
+    el.addEventListener('sh-contribution-submit', handleSubmit);
+    el.addEventListener('sh-contribution-cancel', handleCancel);
     return () => {
-      el.removeEventListener('contribution-submit', handleSubmit);
-      el.removeEventListener('contribution-cancel', handleCancel);
+      el.removeEventListener('sh-contribution-submit', handleSubmit);
+      el.removeEventListener('sh-contribution-cancel', handleCancel);
     };
   }, [itemId, onSubmit, onClose]);
 

--- a/src/components/stocks/CollaboratorsModal.tsx
+++ b/src/components/stocks/CollaboratorsModal.tsx
@@ -44,11 +44,11 @@ export const CollaboratorsModal: React.FC<Props> = ({ stockId, stockLabel, onClo
       void remove(e.detail.collaboratorId);
     };
 
-    el.addEventListener('collaborator-role-change', handleRoleChange);
-    el.addEventListener('collaborator-remove', handleRemove);
+    el.addEventListener('sh-collaborator-role-change', handleRoleChange);
+    el.addEventListener('sh-collaborator-remove', handleRemove);
     return () => {
-      el.removeEventListener('collaborator-role-change', handleRoleChange);
-      el.removeEventListener('collaborator-remove', handleRemove);
+      el.removeEventListener('sh-collaborator-role-change', handleRoleChange);
+      el.removeEventListener('sh-collaborator-remove', handleRemove);
     };
   }, [updateRole, remove, isLoading]);
 

--- a/src/components/stocks/PendingContributionsSection.tsx
+++ b/src/components/stocks/PendingContributionsSection.tsx
@@ -42,11 +42,11 @@ export const PendingContributionsSection: React.FC<Props> = ({
       onContributionReviewed();
     };
 
-    el.addEventListener('contribution-approve', handleApprove);
-    el.addEventListener('contribution-reject', handleReject);
+    el.addEventListener('sh-contribution-approve', handleApprove);
+    el.addEventListener('sh-contribution-reject', handleReject);
     return () => {
-      el.removeEventListener('contribution-approve', handleApprove);
-      el.removeEventListener('contribution-reject', handleReject);
+      el.removeEventListener('sh-contribution-approve', handleApprove);
+      el.removeEventListener('sh-contribution-reject', handleReject);
     };
   }, [review, onContributionReviewed]);
 

--- a/src/types/web-components.d.ts
+++ b/src/types/web-components.d.ts
@@ -128,7 +128,7 @@ declare global {
         exclude?: string;
         disabled?: boolean;
         'data-theme'?: 'light' | 'dark';
-        'onrole-change'?: (e: CustomEvent<{ role: string }>) => void;
+        'onsh-role-change'?: (e: CustomEvent<{ role: string }>) => void;
       };
 
       'sh-contribution-form': React.DetailedHTMLProps<
@@ -139,8 +139,8 @@ declare global {
         'current-quantity'?: number;
         disabled?: boolean;
         'data-theme'?: 'light' | 'dark';
-        'oncontribution-submit'?: (e: CustomEvent<{ suggestedQuantity: number }>) => void;
-        'oncontribution-cancel'?: (e: CustomEvent) => void;
+        'onsh-contribution-submit'?: (e: CustomEvent<{ suggestedQuantity: number }>) => void;
+        'onsh-contribution-cancel'?: (e: CustomEvent) => void;
       };
 
       'sh-contribution-card': React.DetailedHTMLProps<
@@ -156,8 +156,8 @@ declare global {
         status?: 'PENDING' | 'APPROVED' | 'REJECTED';
         disabled?: boolean;
         'data-theme'?: 'light' | 'dark';
-        'oncontribution-approve'?: (e: CustomEvent<{ contributionId: string }>) => void;
-        'oncontribution-reject'?: (e: CustomEvent<{ contributionId: string }>) => void;
+        'onsh-contribution-approve'?: (e: CustomEvent<{ contributionId: string }>) => void;
+        'onsh-contribution-reject'?: (e: CustomEvent<{ contributionId: string }>) => void;
       };
 
       'sh-stat-card': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {


### PR DESCRIPTION
## Contexte
Le Design System a renommé 7 événements custom avec le préfixe `sh-` (breaking change DS#42, publié en v2.0.0-2.0.3). Ce repo était pinné sur `v1.3.3`.

Closes #192

## Changements
- `package.json` : `@stockhub/design-system` bump vers `v2.0.3`
- 4 fichiers adaptés aux nouveaux noms d'événements :
  - `ContributionFormModal.tsx` : `contribution-submit/cancel` → `sh-contribution-submit/cancel`
  - `CollaboratorsModal.tsx` : `collaborator-role-change/remove` → `sh-collaborator-role-change/remove`
  - `PendingContributionsSection.tsx` : `contribution-approve/reject` → `sh-contribution-approve/reject`
  - `types/web-components.d.ts` : types `on...` correspondants mis à jour

## Vérification
- Build + lint + 556 tests unitaires : verts
- **Vérifié en conditions réelles** (backend staging Render.com, données réelles, connecté via Azure AD B2C) : changement de rôle collaborateur testé bout-en-bout dans l'UI — clic réel sur le sélecteur → événement `sh-collaborator-role-change` reçu → appel API réussi → donnée mise à jour (EDITOR → VIEWER → EDITOR, testé dans les deux sens)
- Contributions (approve/reject/submit/cancel) : même mécanisme, pas de données de test disponibles pour un test end-to-end complet (nécessite un compte VIEWER_CONTRIBUTOR), risque résiduel faible

## Test plan
- [x] Build passant
- [x] Lint passant
- [x] Tests unitaires (556 passants)
- [x] Test manuel changement de rôle collaborateur (backend réel)
- [x] Revue humaine avant merge