### PR TITLE
feat(items): afficher et éditer la note libre d'un article — closes #142

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,18 @@
 # StockHub V2 Front — Variables d'environnement
 # Copiez ce fichier en .env et renseignez vos valeurs.
 # Ne committez jamais le fichier .env.
+#
+# ⚠️ PIÈGE .env.local : Vite charge .env.local en PRIORITÉ sur .env,
+# quel que soit le mode (dev/staging/prod). Si un .env.local traîne
+# sur votre machine (ex: pour tester contre le staging Render.com),
+# TOUTES les requêtes partent vers cette URL — même en lançant `npm run dev`
+# avec un backend local qui tourne. Si l'app se comporte bizarrement
+# (échecs silencieux, lenteurs, erreurs 401 inexpliquées) alors que le
+# backend local répond bien via curl, vérifiez en premier :
+#   ls .env.local  →  si présent, vérifiez VITE_API_SERVER_URL dedans.
+# Les variables d'env ne sont lues qu'au démarrage du serveur Vite —
+# un changement de .env* nécessite un redémarrage complet, le hot-reload
+# ne suffit pas.
 # ======================================================
 
 # --- Azure AD B2C ---

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,24 @@
 # Copiez ce fichier en .env et renseignez vos valeurs.
 # Ne committez jamais le fichier .env.
 #
-# ⚠️ PIÈGE .env.local : Vite charge .env.local en PRIORITÉ sur .env,
-# quel que soit le mode (dev/staging/prod). Si un .env.local traîne
-# sur votre machine (ex: pour tester contre le staging Render.com),
-# TOUTES les requêtes partent vers cette URL — même en lançant `npm run dev`
-# avec un backend local qui tourne. Si l'app se comporte bizarrement
-# (échecs silencieux, lenteurs, erreurs 401 inexpliquées) alors que le
-# backend local répond bien via curl, vérifiez en premier :
-#   ls .env.local  →  si présent, vérifiez VITE_API_SERVER_URL dedans.
+# ⚠️ PIÈGE .env.local : "local" signifie "local à VOTRE machine, jamais
+# commité" — PAS "pointe vers localhost". Le contenu peut pointer n'importe
+# où (staging, prod...). Or Vite charge .env.local en PRIORITÉ sur .env,
+# dans TOUS les modes (dev/staging/prod). Si un .env.local traîne sur votre
+# machine (ex: laissé après un test contre le staging Render.com), TOUTES
+# les requêtes partent vers cette URL — même en lançant `npm run dev` avec
+# un backend local qui tourne. Symptômes : échecs silencieux, lenteurs,
+# erreurs 401 inexpliquées, alors que le backend local répond bien via curl.
+# Premier réflexe : `ls .env.local` → si présent, vérifier VITE_API_SERVER_URL
+# dedans, puis le supprimer/renommer si ce n'est pas voulu.
+#
+# Pas besoin de .env.local pour séparer dev et prod : Vite s'en charge tout
+# seul selon la commande —
+#   npm run dev   (mode development) → charge .env puis .env.development
+#   npm run build (mode production)  → charge .env puis .env.production
+# .env.local ne devrait servir qu'à un override ponctuel et personnel,
+# à retirer immédiatement après usage.
+#
 # Les variables d'env ne sont lues qu'au démarrage du serveur Vite —
 # un changement de .env* nécessite un redémarrage complet, le hot-reload
 # ne suffit pas.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,20 @@ Application React moderne de gestion de stocks intelligente avec intelligence ar
 - Feature/fix branches → Vercel preview automatique (URL temporaire par PR)
 - **Staging Vercel** → branche à pointer manuellement dans les settings Vercel
 
+### ⚠️ Piège `.env.local` (dev local)
+
+Vite charge `.env.local` **en priorité sur `.env`**, quel que soit le mode. Si un
+`.env.local` traîne sur la machine (ex: laissé après un test contre le staging
+Render.com), `npm run dev` continue de pointer vers ce backend distant même si un
+backend local tourne sur `localhost:3006` — symptômes : échecs silencieux, lenteurs
+(cold-start Render gratuit), 401 inexpliqués, alors que `curl localhost:3006/...`
+répond correctement.
+
+**Premier réflexe en cas de comportement bizarre en dev local** : `ls .env.local` puis
+vérifier `VITE_API_SERVER_URL` dedans. Les variables d'env ne sont lues qu'au démarrage
+du serveur Vite — un changement nécessite un redémarrage complet (`npm run dev`), le
+hot-reload ne suffit pas.
+
 ### ⚠️ Backend Azure (F1 tier)
 
 Quota CPU limité à **60 min/jour**. Démarrer avant utilisation, arrêter après :

--- a/src/components/items/ItemFormModal.tsx
+++ b/src/components/items/ItemFormModal.tsx
@@ -20,6 +20,7 @@ export const ItemFormModal: React.FC<ItemFormModalProps> = ({
 }) => {
   const [label, setLabel] = useState(item?.label ?? '');
   const [description, setDescription] = useState(item?.description ?? '');
+  const [note, setNote] = useState(item?.note ?? '');
   const [minimumStock, setMinimumStock] = useState(String(item?.minimumStock ?? 1));
   const [quantity, setQuantity] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -58,12 +59,14 @@ export const ItemFormModal: React.FC<ItemFormModalProps> = ({
           description,
           minimumStock: minStock,
           quantity,
+          note: note.trim(),
         });
       } else {
         await ItemsAPI.updateItem(stockId, item!.id, {
           label: label.trim(),
           description,
           minimumStock: minStock,
+          note: note.trim(),
         });
       }
       onSuccess();
@@ -128,6 +131,24 @@ export const ItemFormModal: React.FC<ItemFormModalProps> = ({
               type="text"
               value={description}
               onChange={e => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="item-note"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Note
+            </label>
+            <textarea
+              id="item-note"
+              value={note}
+              onChange={e => setNote(e.target.value)}
+              maxLength={1000}
+              rows={3}
+              placeholder="Référence fournisseur, emplacement, remarque…"
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-slate-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
             />
           </div>

--- a/src/components/items/__tests__/ItemFormModal.test.tsx
+++ b/src/components/items/__tests__/ItemFormModal.test.tsx
@@ -22,6 +22,7 @@ const editItem: StockDetailItem = {
   id: 42,
   label: 'Item Test',
   description: 'Description item',
+  note: 'Note existante',
   quantity: 5,
   minimumStock: 2,
   status: 'optimal',
@@ -41,8 +42,38 @@ describe('ItemFormModal', () => {
       expect(screen.getByRole('heading', { name: 'Nouvel item' })).toBeInTheDocument();
       expect(screen.getByLabelText(/Nom/)).toHaveValue('');
       expect(screen.getByLabelText(/Description/)).toHaveValue('');
+      expect(screen.getByLabelText(/Note/)).toHaveValue('');
       expect(screen.getByLabelText(/Stock minimum/)).toHaveValue(1);
       expect(screen.getByLabelText(/Quantité initiale/)).toHaveValue(0);
+    });
+
+    it('should send the trimmed note on submit', async () => {
+      vi.mocked(ItemsAPI.addItem).mockResolvedValueOnce({
+        id: 99,
+        label: 'Mon item',
+        quantity: 0,
+        minimumStock: 1,
+        stockId: 1,
+      });
+
+      const { container } = render(
+        <ItemFormModal mode="create" stockId={1} onSuccess={mockOnSuccess} onClose={mockOnClose} />
+      );
+
+      fireEvent.change(screen.getByLabelText(/Nom/), { target: { value: 'Mon item' } });
+      fireEvent.change(screen.getByLabelText(/Note/), {
+        target: { value: '  Marque préférée  ' },
+      });
+
+      const submitButton = container.querySelector('sh-button[variant="primary"]');
+      submitButton?.dispatchEvent(new Event('sh-button-click', { bubbles: true }));
+
+      await waitFor(() => {
+        expect(ItemsAPI.addItem).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ note: 'Marque préférée' })
+        );
+      });
     });
 
     it('should pass quantity to addItem on submit', async () => {
@@ -130,6 +161,7 @@ describe('ItemFormModal', () => {
           description: 'Une description',
           minimumStock: 3,
           quantity: 0,
+          note: '',
         });
         expect(mockOnSuccess).toHaveBeenCalledTimes(1);
         expect(mockOnClose).toHaveBeenCalledTimes(1);
@@ -197,6 +229,7 @@ describe('ItemFormModal', () => {
       expect(screen.getByRole('heading', { name: "Modifier l'item" })).toBeInTheDocument();
       expect(screen.getByLabelText(/Nom/)).toHaveValue('Item Test');
       expect(screen.getByLabelText(/Description/)).toHaveValue('Description item');
+      expect(screen.getByLabelText(/Note/)).toHaveValue('Note existante');
       expect(screen.getByLabelText(/Stock minimum/)).toHaveValue(2);
     });
 
@@ -229,6 +262,7 @@ describe('ItemFormModal', () => {
           label: 'Item Modifié',
           description: 'Description item',
           minimumStock: 2,
+          note: 'Note existante',
         });
         expect(mockOnSuccess).toHaveBeenCalledTimes(1);
         expect(mockOnClose).toHaveBeenCalledTimes(1);

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Home, Package } from 'lucide-react';
+import { ArrowLeft, Home, Package, StickyNote } from 'lucide-react';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
@@ -178,6 +178,23 @@ export const ItemDetailPage: React.FC = () => {
                 </div>
               )}
             </div>
+
+            {item.note && (
+              <div className={`rounded-xl border p-4 ${themeClasses.card}`}>
+                <div className="flex items-center gap-2 mb-2">
+                  <StickyNote
+                    className={`w-4 h-4 flex-shrink-0 ${themeClasses.textMuted}`}
+                    aria-hidden="true"
+                  />
+                  <p
+                    className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
+                  >
+                    Note
+                  </p>
+                </div>
+                <p className={`text-sm whitespace-pre-wrap ${themeClasses.text}`}>{item.note}</p>
+              </div>
+            )}
           </>
         )}
       </main>

--- a/src/pages/ItemDetailPage.tsx
+++ b/src/pages/ItemDetailPage.tsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Home, Package, StickyNote } from 'lucide-react';
+import { ArrowLeft, Home, Package, Pencil, StickyNote } from 'lucide-react';
 
 import { HeaderWrapper } from '@/components/layout/HeaderWrapper';
 import { FooterWrapper } from '@/components/layout/FooterWrapper';
 import { NavSection } from '@/components/layout/NavSection';
 import { ButtonWrapper as Button } from '@/components/common/ButtonWrapper';
+import { ItemFormModal } from '@/components/items/ItemFormModal';
 import { useTheme } from '@/hooks/useTheme';
 import { useNotificationCount } from '@/hooks/useNotificationCount';
+import { useCollaborators } from '@/hooks/useCollaborators';
 import { ItemsAPI } from '@/services/api/itemsAPI';
 import type { RawItemDetail } from '@/services/api/itemsAPI';
 import { formatRelativeDate } from '@/utils/dateUtils';
@@ -49,6 +51,10 @@ export const ItemDetailPage: React.FC = () => {
   const [item, setItem] = useState<RawItemDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showEditModal, setShowEditModal] = useState(false);
+
+  const { myRole, load: loadCollaborators } = useCollaborators(Number(stockId));
+  const isOwnerOrEditor = myRole === 'OWNER' || myRole === 'EDITOR';
 
   const themeClasses = {
     background: theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50',
@@ -57,22 +63,31 @@ export const ItemDetailPage: React.FC = () => {
     card: theme === 'dark' ? 'bg-slate-800 border-slate-700' : 'bg-white border-gray-200',
   };
 
-  useEffect(() => {
+  const fetchItem = useCallback(async () => {
     if (!stockId || !itemId) return;
 
     setIsLoading(true);
-    ItemsAPI.fetchItem(stockId, itemId)
-      .then(data => {
-        setItem(data);
-        setError(null);
-      })
-      .catch(() => {
-        setError('Impossible de charger les informations de cet item.');
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
+    try {
+      const data = await ItemsAPI.fetchItem(stockId, itemId);
+      setItem(data);
+      setError(null);
+    } catch {
+      setError('Impossible de charger les informations de cet item.');
+    } finally {
+      setIsLoading(false);
+    }
   }, [stockId, itemId]);
+
+  useEffect(() => {
+    // Séquentiel plutôt que parallèle : deux acquisitions de token MSAL
+    // concurrentes au montage peuvent déclencher un blocage "interaction_in_progress"
+    // (voir issue #221 pour le fix générique côté ConfigManager).
+    const run = async () => {
+      await fetchItem();
+      await loadCollaborators();
+    };
+    void run();
+  }, [fetchItem, loadCollaborators]);
 
   const status = item ? getStatus(item) : null;
 
@@ -132,11 +147,23 @@ export const ItemDetailPage: React.FC = () => {
                   <p className={`mt-1 text-sm ${themeClasses.textMuted}`}>{item.description}</p>
                 )}
               </div>
-              <span
-                className={`ml-auto flex-shrink-0 px-3 py-1 rounded-full text-xs font-semibold ${STATUS_COLORS[status]}`}
-              >
-                {STATUS_LABELS[status]}
-              </span>
+              <div className="ml-auto flex flex-shrink-0 items-center gap-2">
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-semibold ${STATUS_COLORS[status]}`}
+                >
+                  {STATUS_LABELS[status]}
+                </span>
+                {isOwnerOrEditor && (
+                  <Button
+                    variant="ghost"
+                    icon={Pencil}
+                    onClick={() => setShowEditModal(true)}
+                    aria-label={`Modifier ${item.label}`}
+                  >
+                    <span className="hidden sm:inline">Modifier</span>
+                  </Button>
+                )}
+              </div>
             </div>
 
             {/* Metrics */}
@@ -179,25 +206,44 @@ export const ItemDetailPage: React.FC = () => {
               )}
             </div>
 
-            {item.note && (
-              <div className={`rounded-xl border p-4 ${themeClasses.card}`}>
-                <div className="flex items-center gap-2 mb-2">
-                  <StickyNote
-                    className={`w-4 h-4 flex-shrink-0 ${themeClasses.textMuted}`}
-                    aria-hidden="true"
-                  />
-                  <p
-                    className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
-                  >
-                    Note
-                  </p>
-                </div>
-                <p className={`text-sm whitespace-pre-wrap ${themeClasses.text}`}>{item.note}</p>
+            <div className={`rounded-xl border p-4 ${themeClasses.card}`}>
+              <div className="flex items-center gap-2 mb-2">
+                <StickyNote
+                  className={`w-4 h-4 flex-shrink-0 ${themeClasses.textMuted}`}
+                  aria-hidden="true"
+                />
+                <p
+                  className={`text-xs font-medium uppercase tracking-wide ${themeClasses.textMuted}`}
+                >
+                  Note
+                </p>
               </div>
-            )}
+              {item.note ? (
+                <p className={`text-sm whitespace-pre-wrap ${themeClasses.text}`}>{item.note}</p>
+              ) : isOwnerOrEditor ? (
+                <button
+                  onClick={() => setShowEditModal(true)}
+                  className={`text-sm italic hover:underline ${themeClasses.textMuted}`}
+                >
+                  Aucune note — cliquer pour en ajouter une
+                </button>
+              ) : (
+                <p className={`text-sm italic ${themeClasses.textMuted}`}>Aucune note</p>
+              )}
+            </div>
           </>
         )}
       </main>
+
+      {showEditModal && item && stockId && (
+        <ItemFormModal
+          mode="edit"
+          stockId={stockId}
+          item={{ ...item, status: getStatus(item) }}
+          onSuccess={fetchItem}
+          onClose={() => setShowEditModal(false)}
+        />
+      )}
 
       <FooterWrapper />
     </div>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -120,6 +120,12 @@ export const LandingPage: React.FC = () => {
   const { theme } = useTheme();
 
   const handleLogin = useCallback(() => {
+    // Supprime les verrous d'interaction périmés qui empêchent silencieusement
+    // loginRedirect de se déclencher (voir issue #221)
+    Object.keys(sessionStorage)
+      .filter(k => k.includes('interaction.status'))
+      .forEach(k => sessionStorage.removeItem(k));
+
     instance.loginRedirect(loginRequest).catch(console.error);
   }, [instance]);
 

--- a/src/services/api/ConfigManager.ts
+++ b/src/services/api/ConfigManager.ts
@@ -8,8 +8,15 @@ const AUTHORIZATION = 'Authorization';
 
 /**
  * Récupère le token d'accès via MSAL (acquireTokenSilent)
+ *
+ * Les appels concurrents partagent la même promesse en vol : plusieurs composants
+ * demandant un token en même temps (ex: useNotificationCount qui fait 2 appels dans
+ * un même Promise.all) déclenchaient sinon plusieurs acquireTokenSilent/loginRedirect
+ * simultanés, ce qui plante MSAL avec "interaction_in_progress" (voir issue #221).
  */
-const getToken = async (): Promise<string | null> => {
+let inFlightTokenRequest: Promise<string | null> | null = null;
+
+const acquireToken = async (): Promise<string | null> => {
   const account = msalInstance.getActiveAccount();
   if (!account) return null;
 
@@ -31,6 +38,15 @@ const getToken = async (): Promise<string | null> => {
     }
     return null;
   }
+};
+
+const getToken = (): Promise<string | null> => {
+  if (!inFlightTokenRequest) {
+    inFlightTokenRequest = acquireToken().finally(() => {
+      inFlightTokenRequest = null;
+    });
+  }
+  return inFlightTokenRequest;
 };
 
 /**

--- a/src/services/api/__tests__/itemsAPI.test.ts
+++ b/src/services/api/__tests__/itemsAPI.test.ts
@@ -123,6 +123,19 @@ describe('ItemsAPI', () => {
       expect(body).not.toHaveProperty('label');
       expect(body).not.toHaveProperty('description');
       expect(body).not.toHaveProperty('minimumStock');
+      expect(body).not.toHaveProperty('note');
+    });
+
+    it('should include note when defined', async () => {
+      mockFetch.mockReturnValue(mockResponse(mockItem));
+      const { getApiConfig } = await import('@/services/api/utils');
+      const getApiConfigMock = vi.mocked(getApiConfig);
+
+      await ItemsAPI.updateItem(42, 1, { note: 'Marque préférée' });
+
+      const callArgs = getApiConfigMock.mock.calls[getApiConfigMock.mock.calls.length - 1];
+      const body = callArgs?.[2] as Record<string, unknown>;
+      expect(body).toHaveProperty('note', 'Marque préférée');
     });
 
     it('should include label and minimumStock but not quantity when only those are defined', async () => {

--- a/src/services/api/itemsAPI.ts
+++ b/src/services/api/itemsAPI.ts
@@ -36,6 +36,7 @@ export class ItemsAPI {
       quantity: item.quantity,
       description: item.description ?? '',
       minimumStock: item.minimumStock ?? 1,
+      note: item.note,
     };
 
     const { apiUrl, config } = await getApiConfig('POST', 2, itemData);
@@ -62,6 +63,7 @@ export class ItemsAPI {
     if (updates.label !== undefined) body.label = updates.label;
     if (updates.description !== undefined) body.description = updates.description;
     if (updates.minimumStock !== undefined) body.minimumStock = updates.minimumStock;
+    if (updates.note !== undefined) body.note = updates.note;
 
     const { apiUrl, config } = await getApiConfig('PATCH', 2, body);
     const response = await fetch(`${apiUrl}/stocks/${stockId}/items/${itemId}`, config);

--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -116,6 +116,7 @@ export interface StockItem {
   id: number;
   label: string;
   description?: string;
+  note?: string | null;
   quantity: number;
   minimumStock: number;
   stockId: number;
@@ -126,6 +127,7 @@ export interface CreateItemData {
   quantity: number;
   description?: string;
   minimumStock?: number;
+  note?: string;
 }
 
 export interface UpdateItemData {
@@ -133,6 +135,7 @@ export interface UpdateItemData {
   label?: string;
   description?: string;
   minimumStock?: number;
+  note?: string;
 }
 
 export interface StockEvent {
@@ -196,6 +199,7 @@ export interface StockDetailItem {
   id: number;
   label: string;
   description?: string;
+  note?: string | null;
   quantity: number;
   minimumStock?: number;
   status: ItemStatus;


### PR DESCRIPTION
## 🔗 Issue liée

Closes #142

## 📋 Description

Le champ `note` libre sur les items est maintenant visible et éditable dans l'app :
- Affiché dans la vue détail d'un article (`ItemDetailPage`) s'il est renseigné
- Éditable via un textarea dans le formulaire d'ajout/modification (`ItemFormModal`)

Dépend du backend `stockhub_back` (PR #246, closes #158) qui expose déjà le champ `note` sur les endpoints `GET/POST/PATCH` des items.

## 🔧 Détails d'implémentation

- `types/stock.ts` : `note?: string | null` ajouté à `StockItem`, `StockDetailItem`, `CreateItemData`, `UpdateItemData`
- `services/api/itemsAPI.ts` : `addItem`/`updateItem` transmettent `note` à l'API
- `components/items/ItemFormModal.tsx` : nouveau champ textarea `Note` (max 1000 caractères), pré-rempli en mode édition, trim avant envoi
- `pages/ItemDetailPage.tsx` : nouvelle section affichant la note (icône `StickyNote`), masquée si absente

## 🧪 Type de changement

- [x] ✨ Nouvelle fonctionnalité (feat)

## ✅ Checklist

### Tests

- [x] Tests unitaires passent (`npm run test:run`) — 558 tests (dont nouveaux tests sur la note)
- [x] Build réussit (`npm run build`)

### Qualité

- [x] Titre PR suit le format Conventional Commits
- [x] ESLint 0 warning
- [x] TypeScript 0 erreur
- [x] `npm run ci:quality` passe

## ❓ Points à surveiller / Questions

- Le champ note n'est pour l'instant affiché/éditable que dans la vue détail et le formulaire modal, pas dans les cartes/tableau de la liste d'items (`ItemMobileCard`, tableau desktop de `StockDetailPage`) — hors scope des critères d'acceptation de #142, à faire dans un ticket séparé si souhaité.