### PR TITLE
chore(deps): grouper les bumps @azure/msal-browser et msal-react

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      azure-msal:
+        # @azure/msal-react a une peer dependency stricte sur @azure/msal-browser —
+        # les bumper séparément casse systématiquement le CI (ERESOLVE)
+        patterns:
+          - "@azure/msal-browser"
+          - "@azure/msal-react"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## 📋 Description

Les PR dependabot #219 (`msal-browser` 4.27.0→5.17.1) et #216 (`msal-react` 3.0.23→5.5.3) échouent systématiquement en CI (`ERESOLVE`) car `@azure/msal-react` a une peer dependency stricte (`^4.27.0`) sur `@azure/msal-browser`. Les bumper séparément casse toujours la résolution npm.

## 🔧 Détails

Ajoute un groupe `azure-msal` dans `dependabot.yml` pour que ces deux packages soient toujours proposés ensemble dans une seule PR, quel que soit le type de bump (majeur inclus, donc pas couvert par le groupe `minor-and-patch` existant).

## ✅ Checklist

- [x] TypeScript 0 erreur
- [x] Build réussit

## ❓ À faire après merge

Fermer manuellement les PR #219 et #216 (obsolètes, remplacées par la prochaine PR groupée générée par dependabot).