### PR TITLE
fix(knip): ignorer lint-staged (faux positif)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -34,7 +34,7 @@
     "src/utils/unitFormatter.ts",
     "src/utils/containerManager.ts"
   ],
-  "ignoreDependencies": ["lighthouse"],
+  "ignoreDependencies": ["lighthouse", "lint-staged"],
   "ignoreExportsUsedInFile": true,
   "includeEntryExports": false,
   "ignoreBinaries": ["powershell"],


### PR DESCRIPTION
## 📋 Description

`knip` signale `lint-staged` comme dépendance inutilisée et fait échouer `npm run clean:deadcode` (exit 1) — **sur `main` lui-même**, ce qui bloque le hook pre-push de toute nouvelle branche/PR du repo.

`lint-staged` est bien utilisé, mais uniquement via `npx lint-staged` dans `.husky/pre-commit` + sa config dans `package.json` — invisible à l'analyse statique de knip.

## 🔧 Détails

Ajoute `lint-staged` à `ignoreDependencies` dans `knip.json`.

## ✅ Checklist

- [x] `npm run clean:deadcode` passe (exit 0)
- [x] TypeScript 0 erreur
- [x] Build réussit