### PR TITLE
feat(e2e): socle Playwright pour auth interactive Azure AD B2C

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,17 @@
+# ======================================================
+# StockHub V2 Front — Variables pour les tests E2E Playwright
+# Copiez ce fichier en .env.e2e et renseignez vos valeurs.
+# Ne committez jamais le fichier .env.e2e.
+#
+# Ces variables sont lues par Playwright (tests/e2e-frontend), pas par
+# Vite — elles doivent être exportées dans le shell avant `npm run test:e2e`
+# ou chargées via un outil comme dotenv-cli.
+# ======================================================
+
+# URL de l'application à tester (déployée ou locale)
+E2E_BASE_URL=http://localhost:5173
+
+# Compte de test Azure AD B2C (même compte que les tests E2E backend ROPC —
+# voir stockhub_back/docs/technical/e2e-testing.md)
+AZURE_TEST_USERNAME=your-test-account@example.com
+AZURE_TEST_PASSWORD=your-test-account-password

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Lundi 6h UTC — détection régressions e2e sur main
 
+permissions:
+  contents: read
+
 jobs:
   e2e-frontend:
     name: 🧪 Auth + Smoke E2E

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -1,0 +1,42 @@
+name: 🎭 E2E Frontend - Playwright
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Lundi 6h UTC — détection régressions e2e sur main
+
+jobs:
+  e2e-frontend:
+    name: 🧪 Auth + Smoke E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🎭 Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧪 Run E2E tests
+        run: npm run test:e2e
+        env:
+          E2E_BASE_URL: https://stock-hub-v2-front.vercel.app
+          AZURE_TEST_USERNAME: ${{ secrets.AZURE_TEST_USERNAME }}
+          AZURE_TEST_PASSWORD: ${{ secrets.AZURE_TEST_PASSWORD }}
+
+      - name: 📊 Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ dist-ssr
 .env.local
 .env.production
 .env.staging
+.env.e2e
+
+# Playwright
+playwright/.auth/
+playwright-report/
+test-results/
 
 # SSL Certificates
 *.key

--- a/docs/E2E_TESTS_GUIDE.md
+++ b/docs/E2E_TESTS_GUIDE.md
@@ -1,0 +1,65 @@
+# Guide des tests E2E Frontend
+
+## Pourquoi deux approches E2E différentes (backend vs frontend) ?
+
+- **Backend** (`stockhub_back/tests/e2e`) : authentification **ROPC**
+  (`acquireTokenByUsernamePassword` via `@azure/msal-node`, policy
+  `B2C_1_ROPC`). Non-interactif, rapide, mais ne teste que l'API REST — pas
+  l'écran de login réel affiché à l'utilisateur.
+- **Frontend** (ce guide) : authentification **interactive** via Playwright,
+  policy `B2C_1_signupsignin` (celle réellement utilisée par l'app). Simule
+  le vrai parcours utilisateur : clic "Se connecter" → redirection Azure AD
+  B2C → saisie identifiants → retour sur l'app.
+
+## Pattern storageState
+
+L'authentification interactive est coûteuse (redirections réseau réelles
+vers `b2clogin.com`). Elle n'est donc faite **qu'une fois** par run, dans un
+projet Playwright dédié (`setup`), qui sauvegarde l'état de session
+(cookies/sessionStorage) dans `playwright/.auth/user.json`. Les tests
+suivants (projet `authenticated`) réutilisent ce fichier via
+`storageState`, sans repasser par le login.
+
+```
+tests/e2e-frontend/
+  helpers/
+    auth.setup.ts       # login réel, génère playwright/.auth/user.json
+  auth-smoke.e2e.test.ts  # vérifie que la session réutilisée est valide
+```
+
+`playwright/.auth/user.json` n'est jamais committé (voir `.gitignore`).
+
+## Compte de test
+
+Même compte que les tests E2E backend : `sandrine.cipolla@gmail.com`. Un
+compte B2C dédié n'a pas pu être provisionné par API (voir
+`stockhub_back/docs/troubleshooting/e2e-azure-ropc-issues.md`), donc ce
+compte réel est réutilisé pour les deux approches.
+
+## Lancer en local
+
+```bash
+cp .env.e2e.example .env.e2e
+# renseigner AZURE_TEST_USERNAME / AZURE_TEST_PASSWORD dans .env.e2e
+
+npm run dev            # terminal 1 — sert l'app sur http://localhost:5173
+npx dotenv -e .env.e2e -- npm run test:e2e   # terminal 2
+```
+
+Sans `dotenv-cli`, exporter les variables manuellement avant `npm run
+test:e2e` (`E2E_BASE_URL`, `AZURE_TEST_USERNAME`, `AZURE_TEST_PASSWORD`).
+
+## CI
+
+Workflow séparé `.github/workflows/e2e-frontend.yml`, déclenché
+manuellement (`workflow_dispatch`) ou chaque lundi 6h UTC — **pas** sur
+chaque push/PR, pour ne pas rendre la CI principale dépendante d'un vrai
+login réseau contre Azure AD B2C. Nécessite les secrets repo
+`AZURE_TEST_USERNAME` et `AZURE_TEST_PASSWORD`.
+
+## Scope actuel
+
+Ce socle (issue #101) ne couvre que l'authentification + un test de fumée.
+Les tests de workflow complet (création/édition de stocks et d'items,
+vérifications de la base de données) sont traités dans l'issue #66 — voir
+`documentation/ISSUE_E2E_FULL_UI_BACKEND.md`.

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,7 @@
   ],
   "ignore": [
     ".github/workflows/**",
+    "tests/e2e-frontend/helpers/auth.setup.ts",
     "src/test/**",
     "src/**/__tests__/**",
     "src/**/*.test.{ts,tsx}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1832,9 +1833,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1852,9 +1850,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1872,9 +1867,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,9 +1884,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1912,9 +1901,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1932,9 +1918,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1952,9 +1935,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,9 +1952,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2210,9 +2187,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2227,9 +2201,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2244,9 +2215,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2261,9 +2229,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2278,9 +2243,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2295,9 +2257,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2312,9 +2271,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2329,9 +2285,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2445,6 +2398,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -2578,9 +2547,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,9 +2564,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,9 +2581,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2638,9 +2598,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2658,9 +2615,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2678,9 +2632,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6828,6 +6779,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "audit:fps": "node scripts/audit-fps.mjs",
     "audit:a11y": "node scripts/audit-a11y.mjs",
     "audit:datasets": "node scripts/audit-datasets.mjs",
@@ -64,6 +65,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e-frontend',
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: 'authenticated',
+      testMatch: /.*\.e2e\.test\.ts/,
+      use: {
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/e2e-frontend/auth-smoke.e2e.test.ts
+++ b/tests/e2e-frontend/auth-smoke.e2e.test.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentification Azure AD B2C', () => {
+  test("l'utilisateur reste authentifié via le storageState réutilisé", async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).not.toHaveURL(/b2clogin\.com/);
+    await expect(page.getByText('Dashboard')).toBeVisible();
+  });
+});

--- a/tests/e2e-frontend/helpers/auth.setup.ts
+++ b/tests/e2e-frontend/helpers/auth.setup.ts
@@ -1,0 +1,25 @@
+import { test as setup, expect } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate via Azure AD B2C', async ({ page }) => {
+  const username = process.env.AZURE_TEST_USERNAME;
+  const password = process.env.AZURE_TEST_PASSWORD;
+  if (!username || !password) {
+    throw new Error('AZURE_TEST_USERNAME / AZURE_TEST_PASSWORD manquants — voir .env.e2e.example');
+  }
+
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Se connecter' }).click();
+
+  await page.waitForURL(/b2clogin\.com/);
+  await page.getByPlaceholder('Email Address').fill(username);
+  await page.getByPlaceholder('Password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await page.waitForURL(url => !url.hostname.includes('b2clogin.com'));
+  await expect(page.getByText('Dashboard')).toBeVisible();
+
+  await page.context().storageState({ path: authFile });
+});

--- a/tests/e2e-frontend/helpers/auth.setup.ts
+++ b/tests/e2e-frontend/helpers/auth.setup.ts
@@ -10,15 +10,16 @@ setup('authenticate via Azure AD B2C', async ({ page }) => {
   }
 
   await page.goto('/');
+  const appHostname = new URL(page.url()).hostname;
 
   await page.getByRole('button', { name: 'Se connecter' }).click();
 
-  await page.waitForURL(/b2clogin\.com/);
+  await page.waitForURL(url => url.hostname.endsWith('.b2clogin.com'));
   await page.getByPlaceholder('Email Address').fill(username);
   await page.getByPlaceholder('Password').fill(password);
   await page.getByRole('button', { name: 'Sign in' }).click();
 
-  await page.waitForURL(url => !url.hostname.includes('b2clogin.com'));
+  await page.waitForURL(url => url.hostname === appHostname);
   await expect(page.getByText('Dashboard')).toBeVisible();
 
   await page.context().storageState({ path: authFile });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      'tests/e2e-frontend/**',
+    ],
     poolOptions: {
       threads: {
         minThreads: 1,


### PR DESCRIPTION
## Résumé

Prérequis technique de #66 : ajoute le socle Playwright pour tester le vrai parcours de login Azure AD B2C (redirection interactive, policy `B2C_1_signupsignin`), distinct des tests E2E backend qui utilisent ROPC (non-interactif, policy `B2C_1_ROPC`).

## Détails d'implémentation

- `@playwright/test` ajouté en devDependency (Chromium uniquement)
- `playwright.config.ts` : projet `setup` (auth) → `authenticated` (storageState réutilisé), pattern standard Playwright
- `tests/e2e-frontend/helpers/auth.setup.ts` : login réel via `page.getByRole('button', { name: 'Se connecter' })` (le composant `sh-button` du design system expose un shadow DOM ouvert, donc les locators Playwright le traversent nativement) → attente redirection `b2clogin.com` → remplissage formulaire → sauvegarde `storageState`
- `tests/e2e-frontend/auth-smoke.e2e.test.ts` : test de fumée vérifiant que la session réutilisée reste authentifiée
- Réutilise le compte de test et les noms de secrets déjà utilisés côté backend (`AZURE_TEST_USERNAME`/`AZURE_TEST_PASSWORD`) — pas de nouveau compte B2C à provisionner (la création programmatique avait échoué précédemment côté backend)
- Nouveau workflow CI séparé `.github/workflows/e2e-frontend.yml`, déclenché en `workflow_dispatch` + cron hebdomadaire (lundi 6h UTC, même pattern que le workflow E2E backend) — volontairement pas sur chaque push/PR pour ne pas rendre la CI principale dépendante d'un login réseau réel
- `vitest.config.ts` : exclusion de `tests/e2e-frontend/**` pour éviter que Vitest ramasse les fichiers `*.e2e.test.ts`
- `knip.json` : `auth.setup.ts` ignoré (invoqué par le CLI Playwright via `testMatch`, jamais importé — knip le signalait comme fichier mort)
- `docs/E2E_TESTS_GUIDE.md` créé (référencé par l'issue mais inexistant), documente le pattern storageState et la différence avec l'approche ROPC backend

## Scope

Ce ticket pose uniquement l'auth + un test de fumée. Les tests de workflow complet (création/édition de stock, items) sont hors scope — traités dans #66.

## Non vérifié en autonome

Je n'ai pas exécuté le login avec les vraies identifiants (que ce soit en local ou en me connectant moi-même) : j'ai validé la structure du formulaire B2C réel (`input[type=email]`/`input[type=password]`, pas de MFA visible avant soumission) en naviguant sur https://stock-hub-v2-front.vercel.app, mais sans saisir le mot de passe réel. À vérifier :
- Lancer `npm run test:e2e` en local avec un `.env.e2e` rempli, ou déclencher le workflow manuellement (`workflow_dispatch`) une fois les secrets `AZURE_TEST_USERNAME`/`AZURE_TEST_PASSWORD` ajoutés au repo frontend (à faire manuellement dans les settings GitHub si pas déjà présents)
- Confirmer qu'aucune étape MFA n'apparaît après soumission des identifiants (invisible sur le formulaire initial, mais non testé jusqu'au bout)

## Test plan

- [x] `npm run type-check` / `npm run lint` / `npm run test:run` / `npm run build` / `npm run clean:deadcode` verts
- [x] `npx playwright test --list` confirme le wiring de la config (2 tests, 2 projets)
- [ ] `npm run test:e2e` avec identifiants réels (local ou CI `workflow_dispatch`)

Closes #101