### PR TITLE
fix(e2e): réinjecter le sessionStorage MSAL entre les tests Playwright

### DIFF
--- a/docs/E2E_TESTS_GUIDE.md
+++ b/docs/E2E_TESTS_GUIDE.md
@@ -15,19 +15,36 @@
 
 L'authentification interactive est coûteuse (redirections réseau réelles
 vers `b2clogin.com`). Elle n'est donc faite **qu'une fois** par run, dans un
-projet Playwright dédié (`setup`), qui sauvegarde l'état de session
-(cookies/sessionStorage) dans `playwright/.auth/user.json`. Les tests
-suivants (projet `authenticated`) réutilisent ce fichier via
-`storageState`, sans repasser par le login.
+projet Playwright dédié (`setup`), qui sauvegarde l'état de session dans
+`playwright/.auth/user.json`. Les tests suivants (projet `authenticated`)
+réutilisent ce fichier via `storageState`, sans repasser par le login.
 
 ```
 tests/e2e-frontend/
   helpers/
     auth.setup.ts       # login réel, génère playwright/.auth/user.json
+  fixtures.ts            # réinjecte le sessionStorage MSAL (voir piège ci-dessous)
   auth-smoke.e2e.test.ts  # vérifie que la session réutilisée est valide
 ```
 
 `playwright/.auth/user.json` n'est jamais committé (voir `.gitignore`).
+
+### ⚠️ Piège : `storageState` ne capture pas le sessionStorage
+
+MSAL est configuré en `cacheLocation: 'sessionStorage'`
+(`src/config/authConfig.ts`) — choix volontaire côté app pour limiter la
+persistance du token. Or `storageState()` de Playwright ne sauvegarde que
+les **cookies et le localStorage**, jamais le sessionStorage. Sans
+contournement, chaque test du projet `authenticated` repart avec un
+sessionStorage vide → MSAL ne voit plus de session → redirection vers la
+LandingPage au lieu du dashboard.
+
+Solution : `auth.setup.ts` sérialise le sessionStorage dans
+`playwright/.auth/session-storage.json`, et `fixtures.ts` le réinjecte via
+`context.addInitScript()` avant que le code de l'app ne s'exécute. Tous les
+tests du projet `authenticated` doivent importer `test`/`expect` depuis
+`./fixtures` (pas directement `@playwright/test`) pour bénéficier de cette
+réinjection.
 
 ## Compte de test
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
       'coverage/**',
       '**/*.test.{ts,tsx}',
       '**/*.spec.{ts,tsx}',
+      'tests/e2e-frontend/**',
       ] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/tests/e2e-frontend/auth-smoke.e2e.test.ts
+++ b/tests/e2e-frontend/auth-smoke.e2e.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('Authentification Azure AD B2C', () => {
   test("l'utilisateur reste authentifié via le storageState réutilisé", async ({ page }) => {

--- a/tests/e2e-frontend/fixtures.ts
+++ b/tests/e2e-frontend/fixtures.ts
@@ -1,0 +1,21 @@
+import { test as base } from '@playwright/test';
+import { existsSync, readFileSync } from 'fs';
+
+const sessionStorageFile = 'playwright/.auth/session-storage.json';
+
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    if (existsSync(sessionStorageFile)) {
+      const sessionStorageData = readFileSync(sessionStorageFile, 'utf-8');
+      await context.addInitScript(data => {
+        const entries: Record<string, string> = JSON.parse(data);
+        for (const [key, value] of Object.entries(entries)) {
+          window.sessionStorage.setItem(key, value);
+        }
+      }, sessionStorageData);
+    }
+    await use(context);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e-frontend/helpers/auth.setup.ts
+++ b/tests/e2e-frontend/helpers/auth.setup.ts
@@ -1,6 +1,8 @@
 import { test as setup, expect } from '@playwright/test';
+import { writeFileSync } from 'fs';
 
 const authFile = 'playwright/.auth/user.json';
+const sessionStorageFile = 'playwright/.auth/session-storage.json';
 
 setup('authenticate via Azure AD B2C', async ({ page }) => {
   const username = process.env.AZURE_TEST_USERNAME;
@@ -21,6 +23,12 @@ setup('authenticate via Azure AD B2C', async ({ page }) => {
 
   await page.waitForURL(url => url.hostname === appHostname);
   await expect(page.getByText('Dashboard')).toBeVisible();
+
+  // MSAL est configuré en cacheLocation: 'sessionStorage' (src/config/authConfig.ts).
+  // storageState() de Playwright ne capture que cookies + localStorage — le token
+  // MSAL doit donc être sauvegardé et réinjecté séparément (voir fixtures.ts).
+  const sessionStorageData = await page.evaluate(() => JSON.stringify(sessionStorage));
+  writeFileSync(sessionStorageFile, sessionStorageData);
 
   await page.context().storageState({ path: authFile });
 });


### PR DESCRIPTION
## Résumé

Suite au merge de #101, le premier run réel du workflow `e2e-frontend.yml` a révélé un échec du test de fumée : `storageState()` de Playwright ne capture que cookies + localStorage, jamais le `sessionStorage`. Or MSAL est configuré en `cacheLocation: 'sessionStorage'` (`src/config/authConfig.ts`), donc le token n'était pas transporté vers les tests suivants — l'app retombait sur la LandingPage au lieu du dashboard.

**Bonne nouvelle confirmée par ce run** : le login réel (`auth.setup.ts`) est passé sans accroc en 8.7s — pas de MFA/code de vérification bloquant sur la policy `signupsignin`, ce qui levait le principal risque identifié dans le plan initial de #101.

## Correctif

- `auth.setup.ts` sérialise le `sessionStorage` après login dans `playwright/.auth/session-storage.json`
- `tests/e2e-frontend/fixtures.ts` (nouveau) le réinjecte via `context.addInitScript()` avant chaque test — pattern documenté officiellement par Playwright pour ce cas
- `auth-smoke.e2e.test.ts` importe désormais `test`/`expect` depuis `./fixtures`
- `eslint.config.js` : exclusion de `tests/e2e-frontend/**` (le paramètre Playwright `use` des fixtures déclenchait un faux positif `react-hooks/rules-of-hooks`)
- `docs/E2E_TESTS_GUIDE.md` : documente ce piège pour la suite (#66)

## Test plan

- [x] `npm run type-check` / `npm run lint` / `npm run build` / `npm run clean:deadcode` verts
- [x] `npx playwright test --list` confirme le wiring
- [ ] Re-déclencher `workflow_dispatch` sur `e2e-frontend.yml` après merge pour confirmer que les 2 tests passent (setup déjà validé sur le run précédent)