### PR TITLE
fix(e2e): créer playwright/.auth/ avant d'écrire session-storage.json

### DIFF
--- a/tests/e2e-frontend/helpers/auth.setup.ts
+++ b/tests/e2e-frontend/helpers/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup, expect } from '@playwright/test';
-import { writeFileSync } from 'fs';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
 
 const authFile = 'playwright/.auth/user.json';
 const sessionStorageFile = 'playwright/.auth/session-storage.json';
@@ -28,6 +29,7 @@ setup('authenticate via Azure AD B2C', async ({ page }) => {
   // storageState() de Playwright ne capture que cookies + localStorage — le token
   // MSAL doit donc être sauvegardé et réinjecté séparément (voir fixtures.ts).
   const sessionStorageData = await page.evaluate(() => JSON.stringify(sessionStorage));
+  mkdirSync(dirname(sessionStorageFile), { recursive: true });
   writeFileSync(sessionStorageFile, sessionStorageData);
 
   await page.context().storageState({ path: authFile });


### PR DESCRIPTION
## Résumé

Le run CI de #229 a révélé un second bug : \`writeFileSync('playwright/.auth/session-storage.json', …)\` échoue avec \`ENOENT\` sur un checkout CI propre, car \`playwright/.auth/\` n'existe pas encore (gitignored, jamais committé) et \`writeFileSync\` — contrairement à \`storageState()\` — ne crée pas les dossiers parents.

## Correctif

\`mkdirSync(dirname(sessionStorageFile), { recursive: true })\` avant l'écriture. Reproduit et vérifié en local (le dossier n'existe pas non plus sur mon poste avant un premier run réel).

Closes rien de nouveau — fait partie du suivi de #101/#66.

## Test plan

- [x] Reproduction locale de l'absence du dossier confirmée
- [x] type-check / lint / build verts
- [ ] Re-déclencher `workflow_dispatch` après merge pour confirmer le passage complet