### PR TITLE
feat(e2e): premier workflow #66 — création et suppression de stock

### DIFF
--- a/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Création et suppression de stock — workflow complet UI → API → DB', () => {
+  test('crée un stock via le formulaire, le voit apparaître, puis le supprime', async ({
+    page,
+  }) => {
+    const stockLabel = `E2E Stock ${Date.now()}`;
+
+    await page.goto('/dashboard');
+
+    // 1. Ouvrir le formulaire de création
+    await page.getByRole('button', { name: "Ajouter un Stock à l'inventaire" }).click();
+    const formModal = page.getByRole('dialog');
+    await expect(formModal).toBeVisible();
+
+    // 2. Remplir et soumettre
+    await page.locator('#stock-label').fill(stockLabel);
+    await page.locator('#stock-description').fill('Créé par un test E2E automatisé');
+    await page.locator('#stock-category').selectOption('alimentation');
+    await formModal.getByRole('button', { name: 'Créer' }).click();
+
+    // 3. Le formulaire se ferme et le stock apparaît dans la liste (POST /stocks
+    // déclenché en interne par le formulaire — pas de notification de succès dans
+    // l'app, cf. docs/E2E_TESTS_GUIDE.md)
+    await expect(formModal).not.toBeVisible();
+    const stockCard = page.locator(`sh-stock-card[name="${stockLabel}"]`);
+    await expect(stockCard).toBeVisible();
+
+    // 4. Nettoyage — supprime le stock créé pour ne pas polluer le compte réel
+    await page.getByRole('button', { name: `Supprimer ${stockLabel}` }).click();
+    const confirmModal = page.getByRole('dialog', { name: 'Supprimer ce stock ?' });
+    await expect(confirmModal).toBeVisible();
+    await confirmModal.getByRole('button', { name: 'Supprimer' }).click();
+
+    // 5. Le stock a disparu (DELETE /stocks/:id)
+    await expect(stockCard).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Résumé

Premier test de workflow complet pour #66 : ouverture du formulaire → création réelle d'un stock via l'UI (déclenche `POST /stocks` côté backend) → vérification de son apparition dans le dashboard → suppression via le bouton du web component pour ne pas laisser de données de test dans le compte réel utilisé par la CI (le même compte que #101, `AZURE_TEST_USERNAME`).

Couvre les workflows 1 (création) et 4 (suppression, avec confirmation) décrits dans #66.

## Détails d'implémentation

- Sélecteurs réels vérifiés dans le code (pas ceux, obsolètes, esquissés dans l'issue #66 — aucun `data-testid` n'existe dans l'app, pas de notification de succès/toast) :
  - Bouton d'ouverture : `getByRole('button', { name: "Ajouter un Stock à l'inventaire" })` (accessible name via `aria-label`)
  - Champs du formulaire (HTML natif, pas de web component) : `#stock-label`, `#stock-description`, `#stock-category`
  - Catégorie testée : `alimentation` (confirmée dans `StockFormModal.tsx`)
  - Carte créée : `sh-stock-card[name="..."]`
  - Suppression : `getByRole('button', { name: \`Supprimer ${label}\` })` — l'accessible name vient du `.ariaLabel` posé sur le `sh-button` interne (`stockhub_design_system/src/components/organisms/stock-card/sh-stock-card.ts:407`), traversé nativement par l'arbre d'accessibilité sans piercing manuel du shadow DOM
  - Modal de confirmation : `role="dialog"`, titre "Supprimer ce stock ?" (`ConfirmDeleteModal.tsx`)
- Réutilise l'auth + le fixture sessionStorage posés par #101 (`../fixtures`) plutôt que la config Playwright séparée esquissée dans l'issue #66 (un second `webServer` orchestrant frontend+backend en local) — évite de dupliquer une infra déjà validée en CI

## Scope restant pour #66

- Workflow 2 (gestion d'items) et workflow 3 (mise à jour de quantité) — pas encore couverts
- Le label GitHub de #66 est P1 alors que le corps de l'issue indique lui-même "Priorité : P2" — incohérence à trancher séparément (comme pour #30), pas traitée ici

## Test plan

- [x] `npm run type-check` / `npm run lint` / `npm run build` / `npm run clean:deadcode` verts
- [x] `npx playwright test --list` confirme le wiring (3 tests, 2 projets)
- [ ] Confirmer en CI (`workflow_dispatch`) que le workflow complet passe avec le vrai compte

Contribue à #66