### PR TITLE
fix(e2e): forcer workers=1 (course de tokens MSAL entre tests parallèles)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/e2e-frontend',
   fullyParallel: false,
+  // Un seul worker : tous les tests du projet 'authenticated' partagent le
+  // même compte Azure B2C réel. Des tests en parallèle déclenchent des
+  // acquisitions de token MSAL concurrentes, un bug déjà rencontré côté app
+  // (voir ETAT-DU-PROJET.md, session du 23 juillet 2026 — verrou
+  // interaction_in_progress) qui casse le dashboard ("Se reconnecter").
+  workers: 1,
   retries: process.env.CI ? 1 : 0,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {


### PR DESCRIPTION
## Résumé

Le run CI de #232 a échoué sur \`stock-creation.e2e.test.ts\` — après création du stock, le dashboard affichait un écran d'erreur ("Se reconnecter") au lieu du nouveau \`sh-stock-card\`. Diagnostiqué via le snapshot d'accessibilité auto-généré par Playwright (\`error-context.md\`) sans exécuter le test moi-même.

Cause : \`auth-smoke.e2e.test.ts\` et \`stock-creation.e2e.test.ts\` tournaient en parallèle (2 workers) sur le **même compte Azure B2C réel**, déclenchant des acquisitions de token MSAL concurrentes — le même type de bug déjà rencontré côté app et documenté dans \`ETAT-DU-PROJET.md\` (session du 23/07/2026, verrou \`interaction_in_progress\`).

\`fullyParallel: false\` ne suffisait pas : ce flag ne limite que le parallélisme *intra-fichier*, pas *inter-fichiers*. \`workers: 1\` force l'exécution séquentielle de tout le projet \`authenticated\`.

## Test plan

- [x] type-check / lint / build verts
- [ ] Confirmer en CI que les 3 tests passent en séquentiel