### PR TITLE
fix(e2e): remplacer le locator CSS [name=...] par le rôle accessible

### DIFF
--- a/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
@@ -23,7 +23,11 @@ test.describe('Création et suppression de stock — workflow complet UI → API
     // déclenché en interne par le formulaire — pas de notification de succès dans
     // l'app, cf. docs/E2E_TESTS_GUIDE.md)
     await expect(formModal).not.toBeVisible();
-    const stockCard = page.locator(`sh-stock-card[name="${stockLabel}"]`);
+    // Le sélecteur CSS [name="..."] ne fonctionne pas ici : Lit expose `name`
+    // comme propriété JS (définie par React sur l'élément), pas comme
+    // attribut HTML reflété — [name="..."] ne matche donc jamais. On cible
+    // plutôt le rôle accessible réel du composant (article "Carte de stock ...").
+    const stockCard = page.getByRole('article', { name: `Carte de stock ${stockLabel}` });
     await expect(stockCard).toBeVisible();
 
     // 4. Nettoyage — supprime le stock créé pour ne pas polluer le compte réel


### PR DESCRIPTION
## Résumé

Root cause complète, trouvée via App Insights + traces réseau Playwright :

1. **Backend (résolu séparément, hors PR)** : 6 migrations Prisma jamais appliquées en prod depuis fin mars, dont l'ajout de \`items.note\` — \`GET\`/\`POST /api/v2/stocks\` renvoyaient 500 pour **tout le monde**, pas seulement pour le test. Appliqué via \`prisma migrate deploy\` contre la prod (colonnes additives, aucune perte de données).
2. **Frontend (cette PR)** : une fois le backend corrigé, le test échouait encore au même endroit. Le stock était bien créé (confirmé 201 en base + visible dans le DOM via le snapshot d'accessibilité Playwright), mais \`sh-stock-card[name="..."]\` ne matchait jamais — Lit expose \`name\` comme propriété JS, pas comme attribut HTML reflété, donc le sélecteur CSS \`[name=...]\` est structurellement incapable de le cibler.

## Correctif

\`getByRole('article', { name: \`Carte de stock \${stockLabel}\` })\` — matche le rôle accessible réel exposé par le composant, confirmé présent dans les snapshots d'échec précédents.

## Note

Les runs CI précédents (avant ce fix) ont laissé quelques stocks de test orphelins (\`E2E Stock ...\`) dans le compte réel — le test échouait avant d'atteindre l'étape de nettoyage. À supprimer manuellement via le dashboard si besoin, ou ils seront ignorables (préfixe \`E2E Stock\` facilement identifiable).

## Test plan

- [x] type-check / lint / build verts
- [ ] Confirmer en CI que les 3 tests passent enfin de bout en bout