### PR TITLE
feat(e2e): workflows 2 et 3 de #66 — gestion d'items et mise à jour de quantité

### DIFF
--- a/tests/e2e-frontend/helpers/stock-actions.ts
+++ b/tests/e2e-frontend/helpers/stock-actions.ts
@@ -1,0 +1,34 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '../fixtures';
+
+/** Crée un stock via le formulaire UI et retourne le locator de sa carte. */
+export async function createStock(page: Page, label: string): Promise<Locator> {
+  await page.goto('/dashboard');
+
+  await page.getByRole('button', { name: "Ajouter un Stock à l'inventaire" }).click();
+  const formModal = page.getByRole('dialog', { name: 'Nouveau stock' });
+  await expect(formModal).toBeVisible();
+
+  await page.locator('#stock-label').fill(label);
+  await page.locator('#stock-description').fill('Créé par un test E2E automatisé');
+  await page.locator('#stock-category').selectOption('alimentation');
+  await formModal.getByRole('button', { name: 'Créer' }).click();
+
+  await expect(formModal).not.toBeVisible();
+  const stockCard = page.getByRole('article', { name: `Carte de stock ${label}` });
+  await expect(stockCard).toBeVisible();
+  return stockCard;
+}
+
+/** Supprime un stock depuis le dashboard (avec confirmation). */
+export async function deleteStock(page: Page, label: string): Promise<void> {
+  await page.goto('/dashboard');
+  const stockCard = page.getByRole('article', { name: `Carte de stock ${label}` });
+  await page.getByRole('button', { name: `Supprimer ${label}` }).click();
+
+  const confirmModal = page.getByRole('dialog', { name: 'Supprimer ce stock ?' });
+  await expect(confirmModal).toBeVisible();
+  await confirmModal.getByRole('button', { name: 'Supprimer' }).click();
+
+  await expect(stockCard).not.toBeVisible();
+}

--- a/tests/e2e-frontend/workflows/item-management.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/item-management.e2e.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../fixtures';
+import { createStock, deleteStock } from '../helpers/stock-actions';
+
+test.describe('Gestion des items — ajout et statut', () => {
+  test("ajoute un item et vérifie qu'il apparaît avec le statut attendu", async ({ page }) => {
+    const stockLabel = `E2E Stock Items ${Date.now()}`;
+    const itemLabel = `E2E Item ${Date.now()}`;
+
+    const stockCard = await createStock(page, stockLabel);
+
+    // 1. Naviguer vers le détail du stock
+    await stockCard.click();
+    await page.waitForURL(/\/stocks\/\d+$/);
+
+    // 2. Ouvrir le formulaire d'ajout d'item
+    await page.getByRole('button', { name: 'Ajouter un item' }).click();
+    const itemModal = page.getByRole('dialog', { name: 'Nouvel item' });
+    await expect(itemModal).toBeVisible();
+
+    // 3. Remplir avec une quantité sous le seuil minimum pour déclencher le
+    // statut "Critique" (getItemStatus : quantity < minimumStock)
+    await page.getByLabel('Nom', { exact: true }).fill(itemLabel);
+    await page.getByLabel('Quantité initiale', { exact: true }).fill('2');
+    await page.getByLabel('Stock minimum', { exact: true }).fill('10');
+    await itemModal.getByRole('button', { name: 'Créer' }).click();
+    await expect(itemModal).not.toBeVisible();
+
+    // 4. L'item apparaît dans le tableau (vue desktop — vue mobile coexiste
+    // dans le DOM mais cachée en CSS, cf. wiki ADR-011) avec le statut Critique
+    const desktopTable = page.getByTestId('items-desktop-table');
+    const itemRow = desktopTable.locator('tr', { hasText: itemLabel });
+    await expect(itemRow).toBeVisible();
+    await expect(itemRow).toContainText('Critique');
+
+    // 5. Le compteur du filtre de statut reflète le nouvel item critique
+    await expect(page.getByRole('button', { name: /Critique \(\d+\)/ })).toBeVisible();
+
+    // 6. Nettoyage — supprime l'item (confirmation native window.confirm) puis le stock
+    page.once('dialog', dialog => dialog.accept());
+    await itemRow.getByRole('button', { name: `Supprimer ${itemLabel}` }).click();
+    await expect(itemRow).not.toBeVisible();
+
+    await deleteStock(page, stockLabel);
+  });
+});

--- a/tests/e2e-frontend/workflows/quantity-update.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/quantity-update.e2e.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '../fixtures';
+import { createStock, deleteStock } from '../helpers/stock-actions';
+
+test.describe('Mise à jour de quantité — boutons +/-', () => {
+  test('incrémente puis décrémente la quantité via les boutons +/-', async ({ page }) => {
+    const stockLabel = `E2E Stock Qty ${Date.now()}`;
+    const itemLabel = `E2E Item Qty ${Date.now()}`;
+
+    const stockCard = await createStock(page, stockLabel);
+
+    await stockCard.click();
+    await page.waitForURL(/\/stocks\/\d+$/);
+
+    await page.getByRole('button', { name: 'Ajouter un item' }).click();
+    const itemModal = page.getByRole('dialog', { name: 'Nouvel item' });
+    await page.getByLabel('Nom', { exact: true }).fill(itemLabel);
+    await page.getByLabel('Quantité initiale', { exact: true }).fill('5');
+    await page.getByLabel('Stock minimum', { exact: true }).fill('1');
+    await itemModal.getByRole('button', { name: 'Créer' }).click();
+    await expect(itemModal).not.toBeVisible();
+
+    const desktopTable = page.getByTestId('items-desktop-table');
+    const itemRow = desktopTable.locator('tr', { hasText: itemLabel });
+    const quantityValue = itemRow.locator('[data-testid^="qty-edit-span-"]');
+    await expect(quantityValue).toHaveText('5');
+
+    // Le clic sur "+" appelle PATCH /stocks/:id/items/:itemId directement
+    // (handleUpdateQuantity), sans passer par l'input d'édition inline.
+    await itemRow.getByRole('button', { name: `Augmenter la quantité de ${itemLabel}` }).click();
+    await expect(quantityValue).toHaveText('6');
+
+    await itemRow.getByRole('button', { name: `Diminuer la quantité de ${itemLabel}` }).click();
+    await itemRow.getByRole('button', { name: `Diminuer la quantité de ${itemLabel}` }).click();
+    await expect(quantityValue).toHaveText('4');
+
+    // Nettoyage
+    page.once('dialog', dialog => dialog.accept());
+    await itemRow.getByRole('button', { name: `Supprimer ${itemLabel}` }).click();
+    await expect(itemRow).not.toBeVisible();
+
+    await deleteStock(page, stockLabel);
+  });
+});

--- a/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/stock-creation.e2e.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures';
+import { createStock, deleteStock } from '../helpers/stock-actions';
 
 test.describe('Création et suppression de stock — workflow complet UI → API → DB', () => {
   test('crée un stock via le formulaire, le voit apparaître, puis le supprime', async ({
@@ -6,37 +7,14 @@ test.describe('Création et suppression de stock — workflow complet UI → API
   }) => {
     const stockLabel = `E2E Stock ${Date.now()}`;
 
-    await page.goto('/dashboard');
-
-    // 1. Ouvrir le formulaire de création
-    await page.getByRole('button', { name: "Ajouter un Stock à l'inventaire" }).click();
-    const formModal = page.getByRole('dialog', { name: 'Nouveau stock' });
-    await expect(formModal).toBeVisible();
-
-    // 2. Remplir et soumettre
-    await page.locator('#stock-label').fill(stockLabel);
-    await page.locator('#stock-description').fill('Créé par un test E2E automatisé');
-    await page.locator('#stock-category').selectOption('alimentation');
-    await formModal.getByRole('button', { name: 'Créer' }).click();
-
-    // 3. Le formulaire se ferme et le stock apparaît dans la liste (POST /stocks
-    // déclenché en interne par le formulaire — pas de notification de succès dans
-    // l'app, cf. docs/E2E_TESTS_GUIDE.md)
-    await expect(formModal).not.toBeVisible();
-    // Le sélecteur CSS [name="..."] ne fonctionne pas ici : Lit expose `name`
-    // comme propriété JS (définie par React sur l'élément), pas comme
-    // attribut HTML reflété — [name="..."] ne matche donc jamais. On cible
-    // plutôt le rôle accessible réel du composant (article "Carte de stock ...").
-    const stockCard = page.getByRole('article', { name: `Carte de stock ${stockLabel}` });
+    // createStock/deleteStock : voir tests/e2e-frontend/helpers/stock-actions.ts.
+    // Le sélecteur CSS [name="..."] ne fonctionne pas sur sh-stock-card : Lit
+    // expose `name` comme propriété JS (définie par React sur l'élément), pas
+    // comme attribut HTML reflété — on cible le rôle accessible réel du
+    // composant (article "Carte de stock ...").
+    const stockCard = await createStock(page, stockLabel);
     await expect(stockCard).toBeVisible();
 
-    // 4. Nettoyage — supprime le stock créé pour ne pas polluer le compte réel
-    await page.getByRole('button', { name: `Supprimer ${stockLabel}` }).click();
-    const confirmModal = page.getByRole('dialog', { name: 'Supprimer ce stock ?' });
-    await expect(confirmModal).toBeVisible();
-    await confirmModal.getByRole('button', { name: 'Supprimer' }).click();
-
-    // 5. Le stock a disparu (DELETE /stocks/:id)
-    await expect(stockCard).not.toBeVisible();
+    await deleteStock(page, stockLabel);
   });
 });


### PR DESCRIPTION
## Résumé

Complète #66 avec les workflows 2 (gestion d'items) et 3 (mise à jour de quantité), sur le modèle validé de #235 (création/suppression de stock).

## Détails d'implémentation

- **`tests/e2e-frontend/helpers/stock-actions.ts`** (nouveau) : `createStock`/`deleteStock` factorisés depuis `stock-creation.e2e.test.ts`, réutilisés par les 3 tests de workflow — évite la duplication
- **`item-management.e2e.test.ts`** (workflow 2) : crée un item avec quantité sous le seuil minimum → vérifie le statut "Critique" affiché dans `data-testid="items-desktop-table"` + le compteur du filtre (`Critique (N)`), nettoie (item puis stock)
- **`quantity-update.e2e.test.ts`** (workflow 3) : utilise les boutons `+`/`-` (`Augmenter/Diminuer la quantité de {label}`, appel API direct via `handleUpdateQuantity`, pas l'input d'édition inline) pour vérifier la persistance de la quantité affichée (`data-testid="qty-edit-span-{id}"`)

Sélecteurs vérifiés dans le code réel (`StockDetailPage.tsx`, `ItemFormModal.tsx`) — dialog "Nouvel item", champs `getByLabel` (inputs HTML natifs), suppression d'item gérée via `window.confirm` natif (`page.once('dialog', ...)`).

**Vue desktop vs mobile** : les deux vues coexistent dans le DOM (CSS-togglées, cf. wiki ADR-011), donc plusieurs éléments partagent le même `aria-label` — tous les locators sont scopés dans `items-desktop-table` pour éviter les strict-mode violations de Playwright.

## Scope de #66

Avec cette PR, les 4 workflows Must-Have de l'issue #66 sont couverts (création, gestion d'items, mise à jour de quantité, suppression — cette dernière incluse comme étape de nettoyage dans les 3 tests plutôt qu'en test séparé).

## Test plan

- [x] `npm run type-check` / `npm run lint` / `npm run build` / `npm run clean:deadcode` verts
- [x] `npx playwright test --list` confirme le wiring (5 tests, 2 projets)
- [ ] Confirmer en CI (`workflow_dispatch`) que les 5 tests passent

Closes #66