### PR TITLE
fix(e2e): getByLabel('Nom') bloquait 30s sur le formulaire d'item

### DIFF
--- a/tests/e2e-frontend/helpers/item-actions.ts
+++ b/tests/e2e-frontend/helpers/item-actions.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test';
+import { expect } from '../fixtures';
+
+interface AddItemOptions {
+  label: string;
+  quantity: number;
+  minimumStock: number;
+}
+
+/**
+ * Ajoute un item au stock actuellement affiché (page de détail déjà ouverte).
+ * Sélecteurs par id plutôt que getByLabel : le texte réel du <label> "Nom"
+ * est "Nom *" (l'astérisque de champ requis fait partie du texte matché par
+ * getByLabel, malgré le aria-hidden sur le span), donc getByLabel('Nom',
+ * { exact: true }) ne matche jamais et bloque le test jusqu'au timeout.
+ */
+export async function addItem(page: Page, { label, quantity, minimumStock }: AddItemOptions) {
+  await page.getByRole('button', { name: 'Ajouter un item' }).click();
+  const itemModal = page.getByRole('dialog', { name: 'Nouvel item' });
+  await expect(itemModal).toBeVisible();
+
+  await page.locator('#item-label').fill(label);
+  await page.locator('#item-quantity').fill(String(quantity));
+  await page.locator('#item-minimum-stock').fill(String(minimumStock));
+  await itemModal.getByRole('button', { name: 'Créer' }).click();
+  await expect(itemModal).not.toBeVisible();
+}

--- a/tests/e2e-frontend/workflows/item-management.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/item-management.e2e.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures';
 import { createStock, deleteStock } from '../helpers/stock-actions';
+import { addItem } from '../helpers/item-actions';
 
 test.describe('Gestion des items — ajout et statut', () => {
   test("ajoute un item et vérifie qu'il apparaît avec le statut attendu", async ({ page }) => {
@@ -12,30 +13,21 @@ test.describe('Gestion des items — ajout et statut', () => {
     await stockCard.click();
     await page.waitForURL(/\/stocks\/\d+$/);
 
-    // 2. Ouvrir le formulaire d'ajout d'item
-    await page.getByRole('button', { name: 'Ajouter un item' }).click();
-    const itemModal = page.getByRole('dialog', { name: 'Nouvel item' });
-    await expect(itemModal).toBeVisible();
+    // 2. Ajouter un item avec une quantité sous le seuil minimum pour
+    // déclencher le statut "Critique" (getItemStatus : quantity < minimumStock)
+    await addItem(page, { label: itemLabel, quantity: 2, minimumStock: 10 });
 
-    // 3. Remplir avec une quantité sous le seuil minimum pour déclencher le
-    // statut "Critique" (getItemStatus : quantity < minimumStock)
-    await page.getByLabel('Nom', { exact: true }).fill(itemLabel);
-    await page.getByLabel('Quantité initiale', { exact: true }).fill('2');
-    await page.getByLabel('Stock minimum', { exact: true }).fill('10');
-    await itemModal.getByRole('button', { name: 'Créer' }).click();
-    await expect(itemModal).not.toBeVisible();
-
-    // 4. L'item apparaît dans le tableau (vue desktop — vue mobile coexiste
+    // 3. L'item apparaît dans le tableau (vue desktop — vue mobile coexiste
     // dans le DOM mais cachée en CSS, cf. wiki ADR-011) avec le statut Critique
     const desktopTable = page.getByTestId('items-desktop-table');
     const itemRow = desktopTable.locator('tr', { hasText: itemLabel });
     await expect(itemRow).toBeVisible();
     await expect(itemRow).toContainText('Critique');
 
-    // 5. Le compteur du filtre de statut reflète le nouvel item critique
+    // 4. Le compteur du filtre de statut reflète le nouvel item critique
     await expect(page.getByRole('button', { name: /Critique \(\d+\)/ })).toBeVisible();
 
-    // 6. Nettoyage — supprime l'item (confirmation native window.confirm) puis le stock
+    // 5. Nettoyage — supprime l'item (confirmation native window.confirm) puis le stock
     page.once('dialog', dialog => dialog.accept());
     await itemRow.getByRole('button', { name: `Supprimer ${itemLabel}` }).click();
     await expect(itemRow).not.toBeVisible();

--- a/tests/e2e-frontend/workflows/quantity-update.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/quantity-update.e2e.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures';
 import { createStock, deleteStock } from '../helpers/stock-actions';
+import { addItem } from '../helpers/item-actions';
 
 test.describe('Mise à jour de quantité — boutons +/-', () => {
   test('incrémente puis décrémente la quantité via les boutons +/-', async ({ page }) => {
@@ -11,13 +12,7 @@ test.describe('Mise à jour de quantité — boutons +/-', () => {
     await stockCard.click();
     await page.waitForURL(/\/stocks\/\d+$/);
 
-    await page.getByRole('button', { name: 'Ajouter un item' }).click();
-    const itemModal = page.getByRole('dialog', { name: 'Nouvel item' });
-    await page.getByLabel('Nom', { exact: true }).fill(itemLabel);
-    await page.getByLabel('Quantité initiale', { exact: true }).fill('5');
-    await page.getByLabel('Stock minimum', { exact: true }).fill('1');
-    await itemModal.getByRole('button', { name: 'Créer' }).click();
-    await expect(itemModal).not.toBeVisible();
+    await addItem(page, { label: itemLabel, quantity: 5, minimumStock: 1 });
 
     const desktopTable = page.getByTestId('items-desktop-table');
     const itemRow = desktopTable.locator('tr', { hasText: itemLabel });


### PR DESCRIPTION
## Résumé

Le run CI de #238 a révélé que \`item-management.e2e.test.ts\` et \`quantity-update.e2e.test.ts\` échouaient tous les deux sur le même timeout de 30s : \`getByLabel('Nom', { exact: true })\` ne matchait jamais, alors que le champ était bien présent, visible et même focus (confirmé via le snapshot d'accessibilité Playwright).

Cause : le \`<label htmlFor="item-label">\` contient \`Nom\` + un \`<span aria-hidden="true">*</span>\` pour l'astérisque de champ requis. Le texte réel utilisé par \`getByLabel\` inclut ce \`*\` (contrairement à l'accessible name du textbox associé, calculée différemment et qui exclut bien le \`*\`) — donc \`{ exact: true }\` sur \`'Nom'\` ne matche jamais.

## Correctif

Sélecteurs par \`id\` (\`#item-label\`, \`#item-quantity\`, \`#item-minimum-stock\`) — le pattern déjà validé pour le formulaire de stock. Factorisé dans \`tests/e2e-frontend/helpers/item-actions.ts\` (\`addItem\`) pour éviter de dupliquer cette logique dans les deux tests.

## Test plan

- [x] type-check / lint / build verts
- [x] \`npx playwright test --list\` (5 tests, 2 projets)
- [ ] Confirmer en CI que les 5 tests passent enfin