### PR TITLE
chore(e2e): script ponctuel de nettoyage des stocks orphelins

### DIFF
--- a/tests/e2e-frontend/workflows/zzz-cleanup-orphan-stocks.e2e.test.ts
+++ b/tests/e2e-frontend/workflows/zzz-cleanup-orphan-stocks.e2e.test.ts
@@ -1,0 +1,23 @@
+import { test } from '../fixtures';
+
+/**
+ * Script de maintenance ponctuel — supprime les stocks orphelins laissés
+ * par des runs E2E qui ont échoué avant l'étape de nettoyage (préfixe
+ * "E2E Stock", cf. ETAT-DU-PROJET.md session du 24/07/2026).
+ *
+ * À retirer après exécution — ce n'est pas un test de régression, juste
+ * un ménage ponctuel du compte réel utilisé par la CI.
+ */
+test('supprime tous les stocks orphelins préfixés "E2E Stock"', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  for (let i = 0; i < 50; i++) {
+    const deleteButton = page.getByRole('button', { name: /^Supprimer E2E Stock/ }).first();
+    if ((await deleteButton.count()) === 0) break;
+
+    await deleteButton.click();
+    const confirmModal = page.getByRole('dialog', { name: 'Supprimer ce stock ?' });
+    await confirmModal.getByRole('button', { name: 'Supprimer' }).click();
+    await page.waitForTimeout(500);
+  }
+});


### PR DESCRIPTION
Ajoute temporairement un test qui supprime les stocks orphelins préfixés `E2E Stock` accumulés dans le compte réel pendant les runs qui échouaient avant #239. À exécuter une fois via `workflow_dispatch`, puis retiré dans une PR de suivi.