### PR TITLE
feat(e2e): basculer les tests E2E vers le staging (pas la prod)

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -8,8 +8,16 @@
 # ou chargées via un outil comme dotenv-cli.
 # ======================================================
 
-# URL de l'application à tester (déployée ou locale)
-E2E_BASE_URL=http://localhost:5173
+# URL de l'application à tester — staging par défaut (backend Render +
+# base Aiven, isolée de la prod), jamais stock-hub-v2-front.vercel.app
+# (Production Vercel = backend Azure prod). Voir docs/E2E_TESTS_GUIDE.md.
+E2E_BASE_URL=https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app
+
+# Contourne le mur Vercel Authentication (SSO) sur les déploiements Preview
+# — généré dans Vercel → Project Settings → Deployment Protection →
+# "Protection Bypass for Automation". Nécessaire uniquement si E2E_BASE_URL
+# pointe vers une URL Vercel protégée (staging).
+VERCEL_AUTOMATION_BYPASS_SECRET=
 
 # Compte de test Azure AD B2C (même compte que les tests E2E backend ROPC —
 # voir stockhub_back/docs/technical/e2e-testing.md)

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -32,9 +32,12 @@ jobs:
       - name: 🧪 Run E2E tests
         run: npm run test:e2e
         env:
-          E2E_BASE_URL: https://stock-hub-v2-front.vercel.app
+          # Staging (Vercel branche `staging` + backend Render + Aiven MySQL)
+          # — jamais la prod. Voir docs/E2E_TESTS_GUIDE.md.
+          E2E_BASE_URL: https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app
           AZURE_TEST_USERNAME: ${{ secrets.AZURE_TEST_USERNAME }}
           AZURE_TEST_PASSWORD: ${{ secrets.AZURE_TEST_PASSWORD }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: 📊 Upload Playwright report
         if: always()

--- a/docs/E2E_TESTS_GUIDE.md
+++ b/docs/E2E_TESTS_GUIDE.md
@@ -33,10 +33,18 @@ cp .env.e2e.example .env.e2e
 
 ## 2. Utilisation en local (pas à pas)
 
-**Par défaut, cible l'app déployée** (`https://stock-hub-v2-front.vercel.app`)
-— c'est le chemin recommandé, ça marche sans rien démarrer d'autre :
+**Par défaut, cible le staging** (`stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app`,
+backend Render + base Aiven — isolée de la prod) — **jamais**
+`stock-hub-v2-front.vercel.app`, qui est la Production Vercel et pointe
+vers le backend Azure prod (voir §CI plus bas et [[Environnements]] du
+wiki). Le staging est protégé par le mur Vercel Authentication, d'où le
+`VERCEL_AUTOMATION_BYPASS_SECRET` en plus des identifiants B2C (valeur
+dans Vercel → Project Settings → Deployment Protection → "Protection
+Bypass for Automation") :
 
 ```bash
+E2E_BASE_URL=https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app \
+VERCEL_AUTOMATION_BYPASS_SECRET=<valeur du dashboard Vercel> \
 npx dotenv-cli -e .env.e2e -- npx playwright test --ui
 ```
 
@@ -50,10 +58,10 @@ Sans `dotenv-cli`, exporter les variables manuellement :
 
 ```bash
 # PowerShell
-$env:AZURE_TEST_USERNAME="..."; $env:AZURE_TEST_PASSWORD="..."; npx playwright test --ui
+$env:E2E_BASE_URL="https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app"; $env:VERCEL_AUTOMATION_BYPASS_SECRET="..."; $env:AZURE_TEST_USERNAME="..."; $env:AZURE_TEST_PASSWORD="..."; npx playwright test --ui
 
 # bash
-AZURE_TEST_USERNAME=... AZURE_TEST_PASSWORD=... npx playwright test --ui
+E2E_BASE_URL=https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app VERCEL_AUTOMATION_BYPASS_SECRET=... AZURE_TEST_USERNAME=... AZURE_TEST_PASSWORD=... npx playwright test --ui
 ```
 
 ### Ce qui se passe au lancement
@@ -210,9 +218,24 @@ tests/e2e-frontend/
 Workflow séparé `.github/workflows/e2e-frontend.yml`, déclenché
 manuellement (`workflow_dispatch`) ou chaque lundi 6h UTC — **pas** sur
 chaque push/PR, pour ne pas rendre la CI principale dépendante d'un vrai
-login réseau contre Azure AD B2C. Cible l'app déployée
-(`https://stock-hub-v2-front.vercel.app`), nécessite les secrets repo
-`AZURE_TEST_USERNAME` et `AZURE_TEST_PASSWORD`.
+login réseau contre Azure AD B2C.
+
+**Cible le staging** (`https://stock-hub-v2-front-git-staging-sandrinecipollas-projects.vercel.app`,
+backend Render + base Aiven MySQL — isolée de la prod), **jamais**
+`https://stock-hub-v2-front.vercel.app` qui est la Production Vercel et
+pointe vers le backend Azure prod. Un test E2E crée/modifie/supprime des
+données réelles à chaque run — voir [[Environnements]] du wiki pour le
+détail des environnements.
+
+Le staging Vercel est protégé par le mur "Vercel Authentication" (SSO),
+actif par défaut sur les déploiements Preview de l'équipe. La CI le
+contourne via le secret `VERCEL_AUTOMATION_BYPASS_SECRET` (généré dans
+Vercel → Project Settings → Deployment Protection → "Protection Bypass
+for Automation", stocké comme secret GitHub), envoyé en header
+`x-vercel-protection-bypass` sur chaque requête (`playwright.config.ts`).
+
+Secrets repo requis : `AZURE_TEST_USERNAME`, `AZURE_TEST_PASSWORD`,
+`VERCEL_AUTOMATION_BYPASS_SECRET`.
 
 Déclenchement manuel : `gh workflow run e2e-frontend.yml --ref main`.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
   use: {
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
     trace: 'on-first-retry',
+    // Contourne le mur Vercel Deployment Protection sur les URLs de preview
+    // (ex. le staging git-branch) — sans ce header, toute requête est
+    // redirigée vers vercel.com/sso-api avant même d'atteindre l'app.
+    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+      ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+      : undefined,
   },
   projects: [
     {


### PR DESCRIPTION
## Résumé

Découvert en creusant les stocks de test orphelins : `stock-hub-v2-front.vercel.app` (ciblé jusqu'ici par `e2e-frontend.yml`) est la **Production Vercel**, câblée vers le backend Azure prod — confirmé en inspectant le bundle JS déployé (même host que le backend dont j'ai corrigé les migrations plus tôt dans la session). Un vrai staging isolé existe déjà (issues #93/#100, jamais utilisé par les tests E2E jusqu'ici) : Vercel branche `staging` + backend Render + base **Aiven MySQL séparée**.

Pratique standard : une suite E2E complète (create/update/delete) tourne contre un environnement isolé, jamais contre la prod.

## Détails d'implémentation

- `E2E_BASE_URL` pointe désormais vers l'URL staging
- Le staging est derrière le mur **Vercel Authentication (SSO)**, actif par défaut sur les déploiements Preview de l'équipe — contourné via le header `x-vercel-protection-bypass` (`playwright.config.ts`, `extraHTTPHeaders`), alimenté par `VERCEL_AUTOMATION_BYPASS_SECRET`
- `.env.e2e.example` et `docs/E2E_TESTS_GUIDE.md` mis à jour

## ⚠️ Action manuelle requise avant que le workflow CI fonctionne

1. Générer le secret : Vercel → Project Settings → Deployment Protection → "Protection Bypass for Automation" → Add
2. `gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --repo SandrineCipolla/stockHub_V2_front`

## Test plan

- [x] type-check / lint / build verts
- [ ] Confirmer en CI que les tests passent contre le staging une fois le secret ajouté